### PR TITLE
fix: Allow to not send request for offline_access provider scope

### DIFF
--- a/charts/live/templates/deployment.yaml
+++ b/charts/live/templates/deployment.yaml
@@ -205,6 +205,8 @@ spec:
                 key: systemBaseUrl
           - name: CT_SSO_SECURE_JWKS_ENDPT_ENABLE
             value: {{ .Values.sso.jwksEndPointEnabled | quote }}
+          - name: CT_REQUEST_OFFLINE_ACCESS
+            value: {{ .Values.sso.offlineAccessScope | default "true" | quote }}
           {{- end }}
 
           {{- if .Values.securityContext.readOnlyRootFilesystem}}

--- a/charts/live/values.yaml
+++ b/charts/live/values.yaml
@@ -186,7 +186,7 @@ sso:
   clientSecret: "my-id-secret"
   # Set this value to 'true' if you are using Oracle IDCS OpenID Connect.
   jwksEndPointEnabled: false
-
+  offlineAccessScope: true
 #
 # The following sections provide default configurations for the
 # container and normally do not need to be modified.


### PR DESCRIPTION
GitLab SSO provider does not support the "offline_access" scope that CT live sends by default. This change will allow to set the right env variable to not send that scope on the openid request.