### PR TITLE
feat: Add README files for CodeTogether Helm Charts

### DIFF
--- a/charts/collab/README.md
+++ b/charts/collab/README.md
@@ -60,7 +60,6 @@ The following table lists configurable parameters of the CodeTogether Collab cha
 | `av.stunServers.enabled`                    | Enables private STUN servers                                                                  | `false`                                                   |
 | `av.stunServers.server`                     | STUN server address                                                                           | `coturn.example.com`                                      |
 | `av.stunServers.secret`                     | STUN server secret                                                                            | `my-secret`                                               |
-| `sso.enabled`                               | **Deprecated:** SSO integration is now handled by the Intel server, and no configuration is needed in this chart.                  | `false`                                                   |
 | `service.port`                              | Port for CodeTogether Collab service                                                         | `443`                                                     |
 | `restart.enabled`                           | Enables periodic restarts for the server                                                     | `true`                                                    |
 | `restart.cronPattern`                       | Cron pattern for scheduling restarts                                                         | `* 11 * * 0`                                              |

--- a/charts/collab/README.md
+++ b/charts/collab/README.md
@@ -60,12 +60,7 @@ The following table lists configurable parameters of the CodeTogether Collab cha
 | `av.stunServers.enabled`                    | Enables private STUN servers                                                                  | `false`                                                   |
 | `av.stunServers.server`                     | STUN server address                                                                           | `coturn.example.com`                                      |
 | `av.stunServers.secret`                     | STUN server secret                                                                            | `my-secret`                                               |
-| `sso.enabled`                               | Enables Single Sign-On (SSO) integration                                                      | `false`                                                   |
-| `sso.provider`                              | SSO provider name (e.g., OKTA, MICROSOFT, KEYCLOAK)                                           | `OKTA`                                                    |
-| `sso.systemBaseUrl`                         | Base URL for the identity provider                                                            | `https://OKTA_DOMAIN/oauth2/default`                      |
-| `sso.clientID`                              | Client ID for the SSO provider                                                                | `my-oidc-id`                                              |
-| `sso.clientSecret`                          | Client secret for the SSO provider                                                            | `my-id-secret`                                            |
-| `service.type`                              | Kubernetes service type                                                                       | `ClusterIP`                                               |
+| `sso.enabled`                               | **Deprecated:** SSO integration is now handled by the Intel server, and no configuration is needed in this chart.                  | `false`                                                   |
 | `service.port`                              | Port for CodeTogether Collab service                                                         | `443`                                                     |
 | `restart.enabled`                           | Enables periodic restarts for the server                                                     | `true`                                                    |
 | `restart.cronPattern`                       | Cron pattern for scheduling restarts                                                         | `* 11 * * 0`                                              |
@@ -79,6 +74,14 @@ To create a namespace for CodeTogether Collab objects:
 ```bash
 $ kubectl create namespace codetogether-collab
 $ kubectl config set-context --current --namespace=codetogether-collab
+```
+
+## TLS
+
+To secure CodeTogether, you can add a `secret` that contains your TLS (Transport Layer Security) private key and certificate:
+
+```bash
+$ kubectl create secret tls codetogether-tls --key <your-private-key-filename> --cert <your-certificate-filename>
 ```
 
 ## Installing the Chart

--- a/charts/collab/README.md
+++ b/charts/collab/README.md
@@ -29,7 +29,7 @@ The following table lists configurable parameters of the CodeTogether Collab cha
 | `imageCredentials.email`                    | Docker registry email                                                                          | `unused`                                                  |
 | `openshift.enabled`                         | Enables deployment in OpenShift                                                                | `false`                                                   |
 | `intel.url`                                 | URL of the Intel server                                                                        | `https://your-intel-server`                               |
-| `intel.secret`                              | Secret key for connecting to the Intel server                                                  | `SECRET`                                                  |
+| `intel.secret`                             | Secret key used to authenticate with the Intel server for secure communication                | `SECRET`                                                  |
 | `codetogether.mode`                         | CodeTogether running mode (`direct`, `locator-central`, or `locator-edge`)                     | `direct`                                                  |
 | `codetogether.url`                          | Fully Qualified Domain Name (FQDN) for the server                                              | `https://codetogether.local`                              |
 | `codetogether.trustAllCerts`                | Allows untrusted certificates if set to `true`                                                | `true`                                                    |

--- a/charts/collab/README.md
+++ b/charts/collab/README.md
@@ -1,0 +1,113 @@
+# README.md Helm Chart for CodeTogether Collab
+
+## Summary
+
+This chart creates a CodeTogether Collab server deployment on a Kubernetes cluster using the Helm package manager.
+
+## Prerequisites
+
+This chart has been created with Helm v3 and tested with:
+
+- Kubernetes v1.18+
+- Helm v3.5+
+
+## Configuration
+
+The following table lists configurable parameters of the CodeTogether Collab chart and their default values:
+
+| Parameter                                   | Description                                                                                     | Default                                                   |
+|---------------------------------------------|-------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| `nameOverride`                              | Overrides the name of the chart                                                                | `""`                                                     |
+| `fullnameOverride`                          | Overrides the full name of the chart                                                           | `""`                                                     |
+| `image.repository`                          | Docker image repository for CodeTogether Collab                                                | `codetogether/codetogether-collab`                       |
+| `image.pullPolicy`                          | Container image pull policy                                                                    | `Always`                                                  |
+| `image.tag`                                 | Tag for the CodeTogether Collab image                                                          | `latest`                                                  |
+| `imageCredentials.enabled`                  | Enables authentication for private Docker registry                                             | `false`                                                   |
+| `imageCredentials.registry`                 | Docker registry URL                                                                            | `hub.edge.codetogether.com`                               |
+| `imageCredentials.username`                 | Docker registry username                                                                       | `my-customer-username`                                    |
+| `imageCredentials.password`                 | Docker registry password                                                                       | `my-customer-password`                                    |
+| `imageCredentials.email`                    | Docker registry email                                                                          | `unused`                                                  |
+| `openshift.enabled`                         | Enables deployment in OpenShift                                                                | `false`                                                   |
+| `intel.url`                                 | URL of the Intel server                                                                        | `https://your-intel-server`                               |
+| `intel.secret`                              | Secret key for connecting to the Intel server                                                  | `SECRET`                                                  |
+| `codetogether.mode`                         | CodeTogether running mode (`direct`, `locator-central`, or `locator-edge`)                     | `direct`                                                  |
+| `codetogether.url`                          | Fully Qualified Domain Name (FQDN) for the server                                              | `https://codetogether.local`                              |
+| `codetogether.trustAllCerts`                | Allows untrusted certificates if set to `true`                                                | `true`                                                    |
+| `codetogether.noclients`                    | Disables the `/clients` endpoint if set to `true`                                              | `false`                                                   |
+| `codetogether.timeZone.enabled`             | Enables a customized time zone for the container                                               | `false`                                                   |
+| `codetogether.timeZone.region`              | Time zone region for the container                                                             | `America/Chicago`                                         |
+| `direct.metrics.statsdEnabled`              | Enables StatsD metrics collection                                                              | `false`                                                   |
+| `direct.metrics.statsdHost`                 | Host for StatsD metrics                                                                        | `https://my-graphite-fqdn`                                |
+| `direct.metrics.statsdPort`                 | Port for StatsD metrics                                                                        | `8125`                                                    |
+| `direct.metrics.statsdProtocol`             | Protocol for StatsD metrics                                                                    | `UDP`                                                     |
+| `direct.metrics.prometheusEnabled`          | Enables Prometheus metrics collection                                                          | `false`                                                   |
+| `locatorCentral.database.host`              | Host for locator-central database                                                              | `10.10.0.2`                                               |
+| `locatorCentral.database.port`              | Port for locator-central database                                                              | `3306`                                                    |
+| `locatorCentral.database.schema`            | Schema name for locator-central database                                                      | `codetogether`                                            |
+| `locatorCentral.database.dialect`           | Database dialect (`mysql` or `postgres`)                                                      | `mysql`                                                   |
+| `locatorCentral.database.user`              | Username for the database                                                                      | `my-db-username`                                          |
+| `locatorCentral.database.password`          | Password for the database                                                                      | `my-db-password`                                          |
+| `locatorCentral.database.sslEnabled`        | Enables SSL for the database connection                                                       | `false`                                                   |
+| `locatorEdge.locator`                       | URL of the locator for edge mode                                                              | `https://codetogether.locator`                            |
+| `locatorEdge.region`                        | Region for the edge server                                                                     | `default`                                                 |
+| `ingress.enabled`                           | Enables ingress controller resource                                                           | `true`                                                    |
+| `ingress.tls.secretName`                    | TLS secret name for ingress                                                                   | `codetogether-tls`                                        |
+| `dashboard.enabled`                         | Enables the dashboard and allows configuration of credentials                                  | `false`                                                   |
+| `dashboard.username`                        | Dashboard username                                                                             | `my-dashboard-username`                                   |
+| `dashboard.password`                        | Dashboard password                                                                             | `my-dashboard-password`                                   |
+| `av.enabled`                                | Enables audio/video support                                                                   | `false`                                                   |
+| `av.serverIP`                               | IP address for A/V server                                                                      | `auto`                                                    |
+| `av.stunServers.enabled`                    | Enables private STUN servers                                                                  | `false`                                                   |
+| `av.stunServers.server`                     | STUN server address                                                                           | `coturn.example.com`                                      |
+| `av.stunServers.secret`                     | STUN server secret                                                                            | `my-secret`                                               |
+| `sso.enabled`                               | Enables Single Sign-On (SSO) integration                                                      | `false`                                                   |
+| `sso.provider`                              | SSO provider name (e.g., OKTA, MICROSOFT, KEYCLOAK)                                           | `OKTA`                                                    |
+| `sso.systemBaseUrl`                         | Base URL for the identity provider                                                            | `https://OKTA_DOMAIN/oauth2/default`                      |
+| `sso.clientID`                              | Client ID for the SSO provider                                                                | `my-oidc-id`                                              |
+| `sso.clientSecret`                          | Client secret for the SSO provider                                                            | `my-id-secret`                                            |
+| `service.type`                              | Kubernetes service type                                                                       | `ClusterIP`                                               |
+| `service.port`                              | Port for CodeTogether Collab service                                                         | `443`                                                     |
+| `restart.enabled`                           | Enables periodic restarts for the server                                                     | `true`                                                    |
+| `restart.cronPattern`                       | Cron pattern for scheduling restarts                                                         | `* 11 * * 0`                                              |
+| `favicon.enabled`                           | Enables a custom favicon                                                                     | `false`                                                   |
+| `favicon.filePath`                          | Path to the custom favicon                                                                   | `files/new-favicon.ico`                                   |
+
+## Creating your Kubernetes Namespace for CodeTogether Collab
+
+To create a namespace for CodeTogether Collab objects:
+
+```bash
+$ kubectl create namespace codetogether-collab
+$ kubectl config set-context --current --namespace=codetogether-collab
+```
+
+## Installing the Chart
+
+To install the chart with the release name `codetogether-collab`:
+
+```bash
+$ helm install codetogether-collab -f codetogether-values.yaml ./codetogether-collab
+```
+
+You can verify the deployment using:
+
+```bash
+$ helm list
+$ kubectl get all -n codetogether-collab
+```
+
+## Updating the Chart
+
+To upgrade CodeTogether Collab to a newer version:
+
+```bash
+$ helm repo update
+$ helm upgrade codetogether-collab -f codetogether-values.yaml ./codetogether-collab
+```
+
+## Uninstalling the Chart
+
+To uninstall the `codetogether-collab` release:
+
+```bash
+$ helm uninstall codetogether-collab

--- a/charts/collab/values.yaml
+++ b/charts/collab/values.yaml
@@ -189,21 +189,6 @@ av:
   # jitsiUrl: "https://your.jtsi.server"
 
 #
-# Optionally enable integration with your SSO Provider. If using SSO, this
-# should be enabled on every CodeTogether server.
-#
-sso:
-  # Set this to 'true' if you are using an SSO provider.
-  enabled: false
-  # Replace below values with your actual SSO provider configuration.
-  provider: OKTA
-  systemBaseUrl: https://OKTA_DOMAIN/oauth2/default
-  clientID: "my-oidc-id"
-  clientSecret: "my-id-secret"
-  # Set this value to 'true' if you are using Oracle IDCS OpenID Connect.
-  jwksEndPointEnabled: false
-  offlineAccessScope: true
-#
 # The following sections provide default configurations for the
 # container and normally do not need to be modified.
 # -------------------------------------------------------------------------

--- a/charts/hq/README.md
+++ b/charts/hq/README.md
@@ -1,4 +1,9 @@
 # README.md Helm Chart for CodeTogether HQ
+# CodeTogether HQ Chart (Legacy)
+
+> **⚠️ Legacy Chart**  
+> This chart is now considered legacy and is not recommended for new deployments. Please use the `codetogether-intel` chart for configurations requiring `hqproperties.hq.collab.*`.
+
 
 ## Summary
 
@@ -43,9 +48,6 @@ The following table lists configurable parameters of the CodeTogether HQ chart a
 | `hqproperties.hq.sso.redirect.uri`             | Redirect URI for SSO                                                                        | `https://<server-fqdn>/api/v1/auth/sso/success/hq`  |
 | `hqproperties.hq.cassandra.db.password`        | Password for Cassandra database                                                             | `cassandra`                                               |
 | `hqproperties.hq.cassandra.db.username`        | Username for Cassandra database                                                             | `cassandra`                                               |
-| `hqproperties.hq.collab.url`               | URL of the collaboration server integrated with HQ                                              | `https://your-collab-server`                               |
-| `hqproperties.hq.collab.secret`            | Secret key for secure communication with the collaboration server                               | `your-collab-secret`                                       |
-
 | `ingress.enabled`                              | Enables ingress controller resource                                                         | `true`                                                    |
 | `ingress.annotations`                          | Annotations for ingress                                                                      | `{}`                                                      |
 | `ingress.tls.secretName`                       | TLS secret name for ingress                                                                 | `codetogether-hq-tls`                                     |

--- a/charts/hq/README.md
+++ b/charts/hq/README.md
@@ -43,6 +43,9 @@ The following table lists configurable parameters of the CodeTogether HQ chart a
 | `hqproperties.hq.sso.redirect.uri`             | Redirect URI for SSO                                                                        | `https://<server-fqdn>/api/v1/auth/sso/success/hq`  |
 | `hqproperties.hq.cassandra.db.password`        | Password for Cassandra database                                                             | `cassandra`                                               |
 | `hqproperties.hq.cassandra.db.username`        | Username for Cassandra database                                                             | `cassandra`                                               |
+| `hqproperties.hq.collab.url`               | URL of the collaboration server integrated with HQ                                              | `https://your-collab-server`                               |
+| `hqproperties.hq.collab.secret`            | Secret key for secure communication with the collaboration server                               | `your-collab-secret`                                       |
+
 | `ingress.enabled`                              | Enables ingress controller resource                                                         | `true`                                                    |
 | `ingress.annotations`                          | Annotations for ingress                                                                      | `{}`                                                      |
 | `ingress.tls.secretName`                       | TLS secret name for ingress                                                                 | `codetogether-hq-tls`                                     |

--- a/charts/hq/README.md
+++ b/charts/hq/README.md
@@ -48,6 +48,8 @@ The following table lists configurable parameters of the CodeTogether HQ chart a
 | `hqproperties.hq.sso.redirect.uri`             | Redirect URI for SSO                                                                        | `https://<server-fqdn>/api/v1/auth/sso/success/hq`  |
 | `hqproperties.hq.cassandra.db.password`        | Password for Cassandra database                                                             | `cassandra`                                               |
 | `hqproperties.hq.cassandra.db.username`        | Username for Cassandra database                                                             | `cassandra`                                               |
+| `hqproperties.hq.sso.role.mapping.claim`       | Specifies the claim in the SSO token containing user roles                                 | `roles`                                                   |
+| `hqproperties.hq.sso.role.mappings`           | Defines the role mappings for CodeTogether HQ                                              | `cthq_user,project-manager[pm],system-admin[sa]`          |
 | `ingress.enabled`                              | Enables ingress controller resource                                                         | `true`                                                    |
 | `ingress.annotations`                          | Annotations for ingress                                                                      | `{}`                                                      |
 | `ingress.tls.secretName`                       | TLS secret name for ingress                                                                 | `codetogether-hq-tls`                                     |
@@ -62,6 +64,20 @@ The following table lists configurable parameters of the CodeTogether HQ chart a
 | `livenessProbe.initialDelaySeconds`            | Initial delay before liveness probe is initiated                                            | `60`                                                      |
 | `livenessProbe.periodSeconds`                  | Period between liveness probes                                                              | `60`                                                      |
 | `livenessProbe.timeoutSeconds`                 | Timeout for liveness probes                                                                 | `15`                                                      |
+
+## Role Mappings Configuration
+
+The following parameters are used to configure role mappings for the application:
+
+- `hq.sso.role.mapping.claim`: Specifies the claim name in the SSO (Single Sign-On) token that contains the user's roles. In this case, it is set to `roles`.
+
+- `hq.sso.role.mappings`: Defines the mappings for user roles in the system. The mappings are configured as follows:
+  - `cthq_user`: Represents regular users with standard access to the system.
+  - `project-manager[pm]`: Represents project managers, identified with the `[pm]` suffix, who have elevated permissions to manage project-specific operations.
+  - `system-admin[sa]`: Represents system administrators, identified with the `[sa]` suffix, who have the highest level of access, including administrative privileges across the system.
+
+These role mappings ensure that users are assigned appropriate permissions based on their roles, as provided by the SSO service. Proper configuration of these parameters is crucial for maintaining secure and role-based access control within the application.
+
 
 ## Creating your Kubernetes Namespace for CodeTogether HQ
 

--- a/charts/hq/README.md
+++ b/charts/hq/README.md
@@ -1,0 +1,99 @@
+# README.md Helm Chart for CodeTogether HQ
+
+## Summary
+
+This chart creates a CodeTogether HQ server deployment on a Kubernetes cluster using the Helm package manager.
+
+## Prerequisites
+
+This chart has been created with Helm v3 and tested with:
+
+- Kubernetes v1.18+
+- Helm v3.5+
+- Cassandra v3.11+
+
+## Configuration
+
+The following table lists configurable parameters of the CodeTogether HQ chart and their default values:
+
+| Parameter                                      | Description                                                                                   | Default                                                   |
+|------------------------------------------------|-----------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| `nameOverride`                                 | Overrides the name of the chart                                                              | `""`                                                     |
+| `fullnameOverride`                             | Overrides the full name of the chart                                                         | `""`                                                     |
+| `image.repository`                             | Docker image repository for CodeTogether HQ                                                  | `hub.edge.codetogether.com/releases/codetogether-hq`      |
+| `image.pullPolicy`                             | Container image pull policy                                                                  | `Always`                                                  |
+| `image.tag`                                    | Tag for the CodeTogether HQ image                                                            | `latest`                                                  |
+| `imageCredentials.enabled`                     | Enables authentication for private Docker registry                                           | `true`                                                    |
+| `imageCredentials.registry`                    | Docker registry URL                                                                          | `hub.edge.codetogether.com`                               |
+| `imageCredentials.username`                    | Docker registry username                                                                     | `my-customer-username`                                    |
+| `imageCredentials.password`                    | Docker registry password                                                                     | `my-customer-password`                                    |
+| `imageCredentials.email`                       | Docker registry email                                                                        | `unused`                                                  |
+| `codetogether.url`                             | Full URL for the CodeTogether HQ server                                                     | `https://<server-fqdn>`                                   |
+| `hqproperties.hq.sso.client.id`                | Client ID for Single Sign-On (SSO)                                                          | `CLIENTID.apps.googleusercontent.com`                     |
+| `hqproperties.hq.sso.client.secret`            | Client Secret for Single Sign-On (SSO)                                                      | `CLIENTSECRET`                                            |
+| `hqproperties.hq.sso.client.issuer.url`        | Issuer URL for Single Sign-On (SSO)                                                         | `https://accounts.google.com`                             |
+| `hqproperties.name.attr`                       | Name attribute for SSO                                                                       | `name`                                                    |
+| `hqproperties.hq.db.type`                      | Database type for CodeTogether HQ                                                           | `CASSANDRA`                                               |
+| `hqproperties.hq.secret`                       | Secret key for CodeTogether HQ                                                              | `SECRET1`                                                 |
+| `hqproperties.hq.encryption.secret`            | Encryption secret key for CodeTogether HQ                                                   | `SECRET2`                                                 |
+| `hqproperties.hq.base.url`                     | Base URL for CodeTogether HQ                                                                | `https://<server-fqdn>`                                   |
+| `hqproperties.hq.cassandra.db.name`            | Cassandra database name                                                                     | `insights`                                                |
+| `hqproperties.hq.cassandra.db.port`            | Cassandra database port                                                                     | `9042`                                                    |
+| `hqproperties.hq.cassandra.db.host`            | Cassandra database host                                                                     | `codetogether-cassandra.default.svc.cluster.local`        |
+| `hqproperties.hq.sso.redirect.uri`             | Redirect URI for SSO                                                                        | `https://<server-fqdn>/api/v1/auth/sso/success/insights`  |
+| `hqproperties.hq.cassandra.db.password`        | Password for Cassandra database                                                             | `cassandra`                                               |
+| `hqproperties.hq.cassandra.db.username`        | Username for Cassandra database                                                             | `cassandra`                                               |
+| `ingress.enabled`                              | Enables ingress controller resource                                                         | `true`                                                    |
+| `ingress.annotations`                          | Annotations for ingress                                                                      | `{}`                                                      |
+| `ingress.tls.secretName`                       | TLS secret name for ingress                                                                 | `codetogether-hq-tls`                                     |
+| `service.type`                                 | Kubernetes service type                                                                     | `ClusterIP`                                               |
+| `service.port`                                 | Port for CodeTogether HQ service                                                            | `1080`                                                    |
+| `serviceAccount.create`                        | Specifies whether a service account should be created                                       | `true`                                                    |
+| `serviceAccount.name`                          | Name of the service account                                                                 | `codetogether-hq`                                         |
+| `replicaCount`                                 | Number of replicas for CodeTogether HQ deployment                                           | `1`                                                       |
+| `readinessProbe.initialDelaySeconds`           | Initial delay before readiness probe is initiated                                           | `60`                                                      |
+| `readinessProbe.periodSeconds`                 | Period between readiness probes                                                             | `60`                                                      |
+| `readinessProbe.timeoutSeconds`                | Timeout for readiness probes                                                                | `15`                                                      |
+| `livenessProbe.initialDelaySeconds`            | Initial delay before liveness probe is initiated                                            | `60`                                                      |
+| `livenessProbe.periodSeconds`                  | Period between liveness probes                                                              | `60`                                                      |
+| `livenessProbe.timeoutSeconds`                 | Timeout for liveness probes                                                                 | `15`                                                      |
+
+## Creating your Kubernetes Namespace for CodeTogether HQ
+
+It is a best practice to create a dedicated namespace for CodeTogether HQ objects. To create a namespace:
+
+```bash
+$ kubectl create namespace codetogether-hq
+$ kubectl config set-context --current --namespace=codetogether-hq
+```
+
+## Installing the Chart
+
+To install the chart with the release name `codetogether-hq`:
+
+```bash
+$ helm install codetogether-hq -f codetogether-values.yaml ./codetogether-hq
+```
+
+You can verify the deployment using:
+
+```bash
+$ helm list
+$ kubectl get all -n codetogether-hq
+```
+
+## Updating the Chart
+
+To upgrade CodeTogether HQ to a newer version:
+
+```bash
+$ helm repo update
+$ helm upgrade codetogether-hq -f codetogether-values.yaml ./codetogether-hq
+```
+
+## Uninstalling the Chart
+
+To uninstall the `codetogether-hq` release:
+
+```bash
+$ helm uninstall codetogether-hq

--- a/charts/hq/README.md
+++ b/charts/hq/README.md
@@ -37,10 +37,10 @@ The following table lists configurable parameters of the CodeTogether HQ chart a
 | `hqproperties.hq.secret`                       | Secret key for CodeTogether HQ                                                              | `SECRET1`                                                 |
 | `hqproperties.hq.encryption.secret`            | Encryption secret key for CodeTogether HQ                                                   | `SECRET2`                                                 |
 | `hqproperties.hq.base.url`                     | Base URL for CodeTogether HQ                                                                | `https://<server-fqdn>`                                   |
-| `hqproperties.hq.cassandra.db.name`            | Cassandra database name                                                                     | `insights`                                                |
+| `hqproperties.hq.cassandra.db.name`            | Cassandra database name                                                                     | `hq`                                                |
 | `hqproperties.hq.cassandra.db.port`            | Cassandra database port                                                                     | `9042`                                                    |
 | `hqproperties.hq.cassandra.db.host`            | Cassandra database host                                                                     | `codetogether-cassandra.default.svc.cluster.local`        |
-| `hqproperties.hq.sso.redirect.uri`             | Redirect URI for SSO                                                                        | `https://<server-fqdn>/api/v1/auth/sso/success/insights`  |
+| `hqproperties.hq.sso.redirect.uri`             | Redirect URI for SSO                                                                        | `https://<server-fqdn>/api/v1/auth/sso/success/hq`  |
 | `hqproperties.hq.cassandra.db.password`        | Password for Cassandra database                                                             | `cassandra`                                               |
 | `hqproperties.hq.cassandra.db.username`        | Username for Cassandra database                                                             | `cassandra`                                               |
 | `ingress.enabled`                              | Enables ingress controller resource                                                         | `true`                                                    |
@@ -65,6 +65,14 @@ It is a best practice to create a dedicated namespace for CodeTogether HQ object
 ```bash
 $ kubectl create namespace codetogether-hq
 $ kubectl config set-context --current --namespace=codetogether-hq
+```
+
+## TLS
+
+To secure CodeTogether, you can add a `secret` that contains your TLS (Transport Layer Security) private key and certificate:
+
+```bash
+$ kubectl create secret tls codetogether-hq-tls --key <your-private-key-filename> --cert <your-certificate-filename>
 ```
 
 ## Installing the Chart

--- a/charts/hq/templates/deployment.yaml
+++ b/charts/hq/templates/deployment.yaml
@@ -44,11 +44,11 @@ spec:
             - name: properties-volume
               mountPath: /opt/codetogether/runtime/cthq.properties
               subPath: cthq.properties
-            {{ - if .Values.license - }}
+            {{- if .Values.license }}
             - name: license-volume
               mountPath: /opt/codetogether/runtime/license
               subPath: license
-            {{ - end }}
+            {{- end }}
           # 
           # Set container configuration
           #
@@ -83,11 +83,11 @@ spec:
         - name: properties-volume
           secret:
             secretName: {{ if .Values.fullnameOverride }}{{ .Values.fullnameOverride }}-hqproperties{{ else }}hqproperties{{ end }}
-        {{ - if .Values.license - }}
+        {{- if .Values.license }}
         - name: license-volume
           secret:
             secretName: license
-        {{ - end }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/hq/values.yaml
+++ b/charts/hq/values.yaml
@@ -52,6 +52,8 @@ hqproperties:
   hq.sso.redirect.uri: https://<server-fqdn>/api/v1/auth/sso/success/insights
   hq.cassandra.db.password: cassandra
   hq.cassandra.db.username: cassandra
+  hq.collab.url: https://<server-fqdn>
+  hq.collab.secret: SECRET3
   # default datacenter name is 'datacenter1'
   # hq.cassandra.db.localdatacenter: datacenter1
 

--- a/charts/hq/values.yaml
+++ b/charts/hq/values.yaml
@@ -53,7 +53,7 @@ hqproperties:
   hq.cassandra.db.password: cassandra
   hq.cassandra.db.username: cassandra
   hq.sso.role.mapping.claim: roles
-  hq.sso.role.mappings: cthq_user,project-manager[pm],system-admin[sa]
+  hq.sso.role.mappings: cthq_user,project-manager[pm],sys-admin[sa]
   # default datacenter name is 'datacenter1'
   # hq.cassandra.db.localdatacenter: datacenter1
 

--- a/charts/hq/values.yaml
+++ b/charts/hq/values.yaml
@@ -52,8 +52,6 @@ hqproperties:
   hq.sso.redirect.uri: https://<server-fqdn>/api/v1/auth/sso/success/insights
   hq.cassandra.db.password: cassandra
   hq.cassandra.db.username: cassandra
-  hq.collab.url: https://<server-fqdn>
-  hq.collab.secret: SECRET3
   # default datacenter name is 'datacenter1'
   # hq.cassandra.db.localdatacenter: datacenter1
 

--- a/charts/hq/values.yaml
+++ b/charts/hq/values.yaml
@@ -49,9 +49,11 @@ hqproperties:
   hq.cassandra.db.name: insights
   hq.cassandra.db.port: 9042
   hq.cassandra.db.host: codetogether-cassandra.default.svc.cluster.local
-  hq.sso.redirect.uri: https://<server-fqdn>/api/v1/auth/sso/success/insights
+  hq.sso.redirect.uri: https://<server-fqdn>/api/v1/auth/sso/success/hq
   hq.cassandra.db.password: cassandra
   hq.cassandra.db.username: cassandra
+  hq.sso.role.mapping.claim: roles
+  hq.sso.role.mappings: cthq_user,project-manager[pm],system-admin[sa]
   # default datacenter name is 'datacenter1'
   # hq.cassandra.db.localdatacenter: datacenter1
 

--- a/charts/intel/.helmignore
+++ b/charts/intel/.helmignore
@@ -1,0 +1,20 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/intel/Chart.yaml
+++ b/charts/intel/Chart.yaml
@@ -1,0 +1,20 @@
+apiVersion: v2
+name: codetogether-intel
+description: CodeTogether Intel provides advanced project insights for developers
+
+type: application
+version: 1.4.15
+appVersion: "2023.3.0"
+kubeVersion: ">= 1.18.0"
+
+icon: https://www.codetogether.com/wp-content/uploads/2020/02/codetogether-circle-128.png
+home: https://www.codetogether.com
+
+maintainers:
+- email: info@codetogether.com
+  name: CodeTogether Inc.
+
+keywords:
+- codetogether
+- intel
+- insights

--- a/charts/intel/README.md
+++ b/charts/intel/README.md
@@ -1,0 +1,112 @@
+# README.md Helm Chart for CodeTogether Intel
+
+
+
+## Summary
+
+This chart creates a CodeTogether Intel server deployment on a Kubernetes cluster using the Helm package manager.
+
+## Prerequisites
+
+This chart has been created with Helm v3 and tested with:
+
+- Kubernetes v1.18+
+- Helm v3.5+
+- Cassandra v3.11+
+
+## Configuration
+
+The following table lists configurable parameters of the CodeTogether Intel chart and their default values:
+
+| Parameter                                      | Description                                                                                   | Default                                                   |
+|------------------------------------------------|-----------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| `nameOverride`                                 | Overrides the name of the chart                                                              | `""`                                                     |
+| `fullnameOverride`                             | Overrides the full name of the chart                                                         | `""`                                                     |
+| `image.repository`                             | Docker image repository for CodeTogether Intel                                                  | `hub.edge.codetogether.com/releases/codetogether-intel`      |
+| `image.pullPolicy`                             | Container image pull policy                                                                  | `Always`                                                  |
+| `image.tag`                                    | Tag for the CodeTogether Intel image                                                            | `latest`                                                  |
+| `imageCredentials.enabled`                     | Enables authentication for private Docker registry                                           | `true`                                                    |
+| `imageCredentials.registry`                    | Docker registry URL                                                                          | `hub.edge.codetogether.com`                               |
+| `imageCredentials.username`                    | Docker registry username                                                                     | `my-customer-username`                                    |
+| `imageCredentials.password`                    | Docker registry password                                                                     | `my-customer-password`                                    |
+| `imageCredentials.email`                       | Docker registry email                                                                        | `unused`                                                  |
+| `codetogether.url`                             | Full URL for the CodeTogether Intel server                                                     | `https://<server-fqdn>`                                   |
+| `hqproperties.hq.sso.client.id`                | Client ID for Single Sign-On (SSO)                                                          | `CLIENTID.apps.googleusercontent.com`                     |
+| `hqproperties.hq.sso.client.secret`            | Client Secret for Single Sign-On (SSO)                                                      | `CLIENTSECRET`                                            |
+| `hqproperties.hq.sso.client.issuer.url`        | Issuer URL for Single Sign-On (SSO)                                                         | `https://accounts.google.com`                             |
+| `hqproperties.name.attr`                       | Name attribute for SSO                                                                       | `name`                                                    |
+| `hqproperties.hq.db.type`                      | Database type for CodeTogether Intel                                                           | `CASSANDRA`                                               |
+| `hqproperties.hq.secret`                       | Secret key for CodeTogether Intel                                                              | `SECRET1`                                                 |
+| `hqproperties.hq.encryption.secret`            | Encryption secret key for CodeTogether Intel                                                   | `SECRET2`                                                 |
+| `hqproperties.hq.base.url`                     | Base URL for CodeTogether Intel                                                                | `https://<server-fqdn>`                                   |
+| `hqproperties.hq.cassandra.db.name`            | Cassandra database name                                                                     | `intel`                                                |
+| `hqproperties.hq.cassandra.db.port`            | Cassandra database port                                                                     | `9042`                                                    |
+| `hqproperties.hq.cassandra.db.host`            | Cassandra database host                                                                     | `codetogether-cassandra.default.svc.cluster.local`        |
+| `hqproperties.hq.sso.redirect.uri`             | Redirect URI for SSO                                                                        | `https://<server-fqdn>/api/v1/auth/sso/success/intel`  |
+| `hqproperties.hq.cassandra.db.password`        | Password for Cassandra database                                                             | `cassandra`                                               |
+| `hqproperties.hq.cassandra.db.username`        | Username for Cassandra database                                                             | `cassandra`                                               |
+| `hqproperties.hq.collab.url`               | URL of the collaboration server integrated with Intel                                              | `https://your-collab-server`                               |
+| `hqproperties.hq.collab.secret`            | Secret key for secure communication with the collaboration server                               | `SECRET`                                                  |
+
+| `ingress.enabled`                              | Enables ingress controller resource                                                         | `true`                                                    |
+| `ingress.annotations`                          | Annotations for ingress                                                                      | `{}`                                                      |
+| `ingress.tls.secretName`                       | TLS secret name for ingress                                                                 | `codetogether-intel-tls`                                     |
+| `service.type`                                 | Kubernetes service type                                                                     | `ClusterIP`                                               |
+| `service.port`                                 | Port for CodeTogether Intel service                                                            | `1080`                                                    |
+| `serviceAccount.create`                        | Specifies whether a service account should be created                                       | `true`                                                    |
+| `serviceAccount.name`                          | Name of the service account                                                                 | `codetogether-intel`                                         |
+| `replicaCount`                                 | Number of replicas for CodeTogether Intel deployment                                           | `1`                                                       |
+| `readinessProbe.initialDelaySeconds`           | Initial delay before readiness probe is initiated                                           | `60`                                                      |
+| `readinessProbe.periodSeconds`                 | Period between readiness probes                                                             | `60`                                                      |
+| `readinessProbe.timeoutSeconds`                | Timeout for readiness probes                                                                | `15`                                                      |
+| `livenessProbe.initialDelaySeconds`            | Initial delay before liveness probe is initiated                                            | `60`                                                      |
+| `livenessProbe.periodSeconds`                  | Period between liveness probes                                                              | `60`                                                      |
+| `livenessProbe.timeoutSeconds`                 | Timeout for liveness probes                                                                 | `15`                                                      |
+
+## Creating your Kubernetes Namespace for CodeTogether Intel
+
+It is a best practice to create a dedicated namespace for CodeTogether Intel objects. To create a namespace:
+
+```bash
+$ kubectl create namespace codetogether-intel
+$ kubectl config set-context --current --namespace=codetogether-intel
+```
+
+## TLS
+
+To secure CodeTogether, you can add a `secret` that contains your TLS (Transport Layer Security) private key and certificate:
+
+```bash
+$ kubectl create secret tls codetogether-intel-tls --key <your-private-key-filename> --cert <your-certificate-filename>
+```
+
+## Installing the Chart
+
+To install the chart with the release name `codetogether-intel`:
+
+```bash
+$ helm install codetogether-intel -f codetogether-values.yaml ./codetogether-intel
+```
+
+You can verify the deployment using:
+
+```bash
+$ helm list
+$ kubectl get all -n codetogether-intel
+```
+
+## Updating the Chart
+
+To upgrade CodeTogether Intel to a newer version:
+
+```bash
+$ helm repo update
+$ helm upgrade codetogether-intel -f codetogether-values.yaml ./codetogether-intel
+```
+
+## Uninstalling the Chart
+
+To uninstall the `codetogether-intel` release:
+
+```bash
+$ helm uninstall codetogether-intel

--- a/charts/intel/templates/NOTES.txt
+++ b/charts/intel/templates/NOTES.txt
@@ -1,0 +1,5 @@
+Application URL:
+{{- if .Values.ingress.enabled }}
+  {{- $host := (urlParse .Values.codetogether.url).host }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host }}{{ .path }}
+{{- end }}

--- a/charts/intel/templates/_helpers.tpl
+++ b/charts/intel/templates/_helpers.tpl
@@ -1,0 +1,86 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "codetogether.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "codetogether.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "codetogether.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "codetogether.labels" -}}
+helm.sh/chart: {{ include "codetogether.chart" . }}
+{{ include "codetogether.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "codetogether.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "codetogether.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "codetogether.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "codetogether.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Creating Image Pull Secrets
+https://helm.sh/docs/howto/charts_tips_and_tricks/#creating-image-pull-secrets
+*/}}
+{{- define "imagePullSecret" }}
+{{- with .Values.imageCredentials }}
+{{- printf "{\"auths\":{\"%s\":{\"username\":\"%s\",\"password\":\"%s\",\"email\":\"%s\",\"auth\":\"%s\"}}}" .registry .username .password .email (printf "%s:%s" .username .password | b64enc) | b64enc }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get Proxy secret name
+*/}}
+{{- define "codetogether.proxy.secretName" }}
+{{- if .Values.proxy.existingSecret }}
+  {{- .Values.proxy.existingSecret }}
+{{- else }}
+  {{- $fullName := include "codetogether.fullname" . -}}
+  {{- with .Values.proxy }}
+    {{- printf "%s-proxy-secret" $fullName }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -1,0 +1,102 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "codetogether.fullname" . }}
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "codetogether.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/properties: {{ include (print $.Template.BasePath "/secret-properties.yaml") . | sha256sum }}
+      {{- with .Values.podAnnotations }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "codetogether.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.imageCredentials.pullSecret }}
+      imagePullSecrets:
+        - name: {{ .Values.imageCredentials.pullSecret }}
+      {{- else if eq .Values.imageCredentials.enabled true }}
+      imagePullSecrets:
+        - name: {{ include "codetogether.fullname" . }}-pull-secret
+      {{- end }}
+      serviceAccountName: {{ include "codetogether.serviceAccountName" . }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+          env:
+          #
+          # Set CodeTogether runtime configuration
+          #         
+          - name: CT_HQ_BASE_URL
+            value: {{ .Values.codetogether.url | quote }}
+          volumeMounts:
+            - name: properties-volume
+              mountPath: /opt/codetogether/runtime/cthq.properties
+              subPath: cthq.properties
+            {{ - if .Values.license - }}
+            - name: license-volume
+              mountPath: /opt/codetogether/runtime/license
+              subPath: license
+            {{ - end }}
+          # 
+          # Set container configuration
+          #
+          ports:
+            - name: http
+              containerPort: 1080
+              protocol: TCP
+          
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            httpGet:
+              path: /
+              port: http
+          
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            httpGet:
+              path: /
+              port: http
+
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: properties-volume
+          secret:
+            secretName: {{ if .Values.fullnameOverride }}{{ .Values.fullnameOverride }}-hqproperties{{ else }}hqproperties{{ end }}
+        {{ - if .Values.license - }}
+        - name: license-volume
+          secret:
+            secretName: license
+        {{ - end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/intel/templates/ingress-class.yaml
+++ b/charts/intel/templates/ingress-class.yaml
@@ -1,0 +1,10 @@
+{{- if and .Values.ingress.enabled (eq .Values.ingress.className "codetogether-nginx") -}}
+apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+  name: codetogether-nginx
+spec:
+  controller: k8s.io/ingress-nginx
+{{- end }}

--- a/charts/intel/templates/ingress.yaml
+++ b/charts/intel/templates/ingress.yaml
@@ -1,0 +1,47 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "codetogether.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- $host := (urlParse .Values.codetogether.url).host }}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end}}
+  {{- if .Values.ingress.tls }}
+  tls:
+    - hosts:
+        - {{ $host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName }}
+  {{- end }}
+  rules:
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: /
+            {{- if (semverCompare ">=1.18" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: "Prefix"
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+{{- end }}

--- a/charts/intel/templates/secret-properties.yaml
+++ b/charts/intel/templates/secret-properties.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ if .Values.fullnameOverride }}{{ .Values.fullnameOverride }}-hqproperties{{ else }}hqproperties{{ end }}
+type: Opaque
+stringData:
+  cthq.properties: |-
+    {{- range $key, $value := .Values.hqproperties }}
+       {{ $key }}={{ $value }}
+    {{- end }}

--- a/charts/intel/templates/secret-pullimage.yaml
+++ b/charts/intel/templates/secret-pullimage.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.imageCredentials.pullSecret }}
+# If using already configured secret, we don't need our own
+{{- else if eq .Values.imageCredentials.enabled true }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "codetogether.fullname" . }}-pull-secret
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end }}

--- a/charts/intel/templates/service.yaml
+++ b/charts/intel/templates/service.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "codetogether.fullname" . }}
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "codetogether.selectorLabels" . | nindent 4 }}

--- a/charts/intel/templates/serviceaccount.yaml
+++ b/charts/intel/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "codetogether.serviceAccountName" . }}
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/intel/templates/tests/test-connection.yaml
+++ b/charts/intel/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "codetogether.fullname" . }}-test-connection"
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "codetogether.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -1,0 +1,124 @@
+# Default values for CodeTogether Intel.
+# This is a YAML-formatted file.
+#
+# Kubernetes required version: v1.18+
+#
+# Example 'values.yaml' file for running CodeTogether Intel On-Premises.
+# Use this file as a template to create your own 'codetogether-values.yaml' file.
+# For full detail on the chart's prerequisites, settings and configuration, please refer to our official Helm repository at:
+#   https://artifacthub.io/packages/helm/codetogether/codetogether
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: hub.edge.codetogether.com/releases/codetogether-intel
+  pullPolicy: Always
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "latest"
+
+#
+# Configure the source location for the Docker image, using the
+# credentials provided by your CodeTogether Sales Representative.
+#
+imageCredentials:
+  # pullSecret: "my-customer-pull-secret"
+  # Use pullSecret or configure credentials if using private Docker registry.
+  enabled: true
+  registry: hub.edge.codetogether.com
+  username: "my-customer-username"
+  password: "my-customer-password"
+  email: unused
+
+#
+# Set CodeTogether runing mode and server's FQDN (HTTPS is mandatory for CodeTogether)
+# Use 'direct' for simple evaluations and small deployments. CodeTogether can provide
+# guidance on the best deployment option based on your needs.
+#
+codetogether:
+  url: https://<server-fqdn>
+
+hqproperties:
+  hq.sso.client.id: CLIENTID.apps.googleusercontent.com
+  hq.sso.client.secret: CLIENTSECRET
+  hq.sso.client.issuer.url: https://accounts.google.com
+  name.attr: name
+  hq.db.type: CASSANDRA
+  hq.secret: SECRET1
+  hq.encryption.secret: SECRET2
+  hq.base.url: https://<server-fqdn>
+  hq.cassandra.db.name: insights
+  hq.cassandra.db.port: 9042
+  hq.cassandra.db.host: codetogether-cassandra.default.svc.cluster.local
+  hq.sso.redirect.uri: https://<server-fqdn>/api/v1/auth/sso/success/insights
+  hq.cassandra.db.password: cassandra
+  hq.cassandra.db.username: cassandra
+  hq.collab.url: https://<server-fqdn>
+  hq.collab.secret: SECRET3
+  # default datacenter name is 'datacenter1'
+  # hq.cassandra.db.localdatacenter: datacenter1
+
+#
+# Enables and configures Ingress (default = Nginx). The className value can be used
+# to change the default behavior. Please read the comments below to see details.
+#
+ingress:
+  enabled: true
+  annotations:
+    # For reference: This is required for k8 version < 1.18
+    # kubernetes.io/ingress.class: nginx
+    # external-dns.alpha.kubernetes.io/hostname: <server-fqdn>
+  # There are 3 ways to handle ingressClassName for the CodeTogether Ingress object:
+  # (1) set className to 'codetogether-nginx' to use the predefined IngressClass
+  # (2) set className to a custom value to use your own IngressClass
+  # (3) do not specify className to rely on the default IngressClass for the cluster (default)
+  # className: codetogether-nginx
+  tls:
+    secretName: codetogether-intel-tls
+
+#
+# The following sections provide default configurations for the
+# container and normally do not need to be modified.
+# -------------------------------------------------------------------------
+#
+service:
+  # annotations:
+    # external-dns.alpha.kubernetes.io/hostname: <server-fqdn>
+  type: ClusterIP
+  port: 1080
+
+serviceAccount:
+  create: true
+  annotations: {}
+  name: "codetogether-intel"
+
+podAnnotations: {}
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+readinessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 60
+  timeoutSeconds: 15
+  successThreshold: 1
+  failureThreshold: 1
+
+livenessProbe:
+  initialDelaySeconds: 60
+  periodSeconds: 60
+  timeoutSeconds: 15
+  successThreshold: 1
+  failureThreshold: 1
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+replicaCount: 1

--- a/charts/live/README.md
+++ b/charts/live/README.md
@@ -81,6 +81,14 @@ $ kubectl create namespace codetogether-live
 $ kubectl config set-context --current --namespace=codetogether-live
 ```
 
+## TLS
+
+To secure CodeTogether, you can add a `secret` that contains your TLS (Transport Layer Security) private key and certificate:
+
+```bash
+$ kubectl create secret tls codetogether-tls --key <your-private-key-filename> --cert <your-certificate-filename>
+```
+
 ## Installing the Chart
 
 To install the chart with the release name `codetogether-live`:

--- a/charts/live/README.md
+++ b/charts/live/README.md
@@ -1,0 +1,113 @@
+# README.md Helm Chart for CodeTogether Live
+
+## Summary
+
+This chart creates a CodeTogether Live server deployment on a Kubernetes cluster using the Helm package manager.
+
+## Prerequisites
+
+This chart has been created with Helm v3 and tested with:
+
+- Kubernetes v1.18+
+- Helm v3.5+
+
+## Configuration
+
+The following table lists configurable parameters of the CodeTogether Live chart and their default values:
+
+| Parameter                                   | Description                                                                                     | Default                                                   |
+|---------------------------------------------|-------------------------------------------------------------------------------------------------|-----------------------------------------------------------|
+| `nameOverride`                              | Overrides the name of the chart                                                                | `""`                                                     |
+| `fullnameOverride`                          | Overrides the full name of the chart                                                           | `""`                                                     |
+| `image.repository`                          | Docker image repository for CodeTogether Live                                                  | `codetogether/codetogether`                               |
+| `image.pullPolicy`                          | Container image pull policy                                                                    | `Always`                                                  |
+| `image.tag`                                 | Tag for the CodeTogether Live image                                                            | `latest`                                                  |
+| `imageCredentials.enabled`                  | Enables authentication for private Docker registry                                             | `false`                                                   |
+| `imageCredentials.registry`                 | Docker registry URL                                                                            | `hub.edge.codetogether.com`                               |
+| `imageCredentials.username`                 | Docker registry username                                                                       | `my-customer-username`                                    |
+| `imageCredentials.password`                 | Docker registry password                                                                       | `my-customer-password`                                    |
+| `imageCredentials.email`                    | Docker registry email                                                                          | `unused`                                                  |
+| `openshift.enabled`                         | Enables deployment in OpenShift                                                                | `false`                                                   |
+| `license.url`                               | URL to the CodeTogether HQ license server                                                     | `https://your-hq-server`                                  |
+| `license.token`                             | Token for authenticating with the license server                                               | `my-hq-token`                                             |
+| `codetogether.mode`                         | CodeTogether running mode (`direct`, `locator-central`, or `locator-edge`)                     | `direct`                                                  |
+| `codetogether.url`                          | Fully Qualified Domain Name (FQDN) for the server                                              | `https://codetogether.local`                              |
+| `codetogether.trustAllCerts`                | Allows untrusted certificates if set to `true`                                                | `true`                                                    |
+| `codetogether.noclients`                    | Disables the `/clients` endpoint if set to `true`                                              | `false`                                                   |
+| `codetogether.timeZone.enabled`             | Enables a customized time zone for the container                                               | `false`                                                   |
+| `codetogether.timeZone.region`              | Time zone region for the container                                                             | `America/Chicago`                                         |
+| `direct.metrics.statsdEnabled`              | Enables StatsD metrics collection                                                              | `false`                                                   |
+| `direct.metrics.statsdHost`                 | Host for StatsD metrics                                                                        | `https://my-graphite-fqdn`                                |
+| `direct.metrics.statsdPort`                 | Port for StatsD metrics                                                                        | `8125`                                                    |
+| `direct.metrics.statsdProtocol`             | Protocol for StatsD metrics                                                                    | `UDP`                                                     |
+| `direct.metrics.prometheusEnabled`          | Enables Prometheus metrics collection                                                          | `false`                                                   |
+| `locatorCentral.database.host`              | Host for locator-central database                                                              | `10.10.0.2`                                               |
+| `locatorCentral.database.port`              | Port for locator-central database                                                              | `3306`                                                    |
+| `locatorCentral.database.schema`            | Schema name for locator-central database                                                      | `codetogether`                                            |
+| `locatorCentral.database.dialect`           | Database dialect (`mysql` or `postgres`)                                                      | `mysql`                                                   |
+| `locatorCentral.database.user`              | Username for the database                                                                      | `my-db-username`                                          |
+| `locatorCentral.database.password`          | Password for the database                                                                      | `my-db-password`                                          |
+| `locatorCentral.database.sslEnabled`        | Enables SSL for the database connection                                                       | `false`                                                   |
+| `locatorEdge.locator`                       | URL of the locator for edge mode                                                              | `https://codetogether.locator`                            |
+| `locatorEdge.region`                        | Region for the edge server                                                                     | `default`                                                 |
+| `ingress.enabled`                           | Enables ingress controller resource                                                           | `true`                                                    |
+| `ingress.tls.secretName`                    | TLS secret name for ingress                                                                   | `codetogether-tls`                                        |
+| `dashboard.enabled`                         | Enables the dashboard and allows configuration of credentials                                  | `false`                                                   |
+| `dashboard.username`                        | Dashboard username                                                                             | `my-dashboard-username`                                   |
+| `dashboard.password`                        | Dashboard password                                                                             | `my-dashboard-password`                                   |
+| `av.enabled`                                | Enables audio/video support                                                                   | `false`                                                   |
+| `av.serverIP`                               | IP address for A/V server                                                                      | `auto`                                                    |
+| `av.stunServers.enabled`                    | Enables private STUN servers                                                                  | `false`                                                   |
+| `av.stunServers.server`                     | STUN server address                                                                           | `coturn.example.com`                                      |
+| `av.stunServers.secret`                     | STUN server secret                                                                            | `my-secret`                                               |
+| `sso.enabled`                               | Enables Single Sign-On (SSO) integration                                                      | `false`                                                   |
+| `sso.provider`                              | SSO provider name (e.g., OKTA, MICROSOFT, KEYCLOAK)                                           | `OKTA`                                                    |
+| `sso.systemBaseUrl`                         | Base URL for the identity provider                                                            | `https://OKTA_DOMAIN/oauth2/default`                      |
+| `sso.clientID`                              | Client ID for the SSO provider                                                                | `my-oidc-id`                                              |
+| `sso.clientSecret`                          | Client secret for the SSO provider                                                            | `my-id-secret`                                            |
+| `service.type`                              | Kubernetes service type                                                                       | `ClusterIP`                                               |
+| `service.port`                              | Port for CodeTogether Live service                                                           | `443`                                                     |
+| `restart.enabled`                           | Enables periodic restarts for the server                                                     | `true`                                                    |
+| `restart.cronPattern`                       | Cron pattern for scheduling restarts                                                         | `* 11 * * 0`                                              |
+| `favicon.enabled`                           | Enables a custom favicon                                                                     | `false`                                                   |
+| `favicon.filePath`                          | Path to the custom favicon                                                                   | `files/new-favicon.ico`                                   |
+
+## Creating your Kubernetes Namespace for CodeTogether Live
+
+To create a namespace for CodeTogether Live objects:
+
+```bash
+$ kubectl create namespace codetogether-live
+$ kubectl config set-context --current --namespace=codetogether-live
+```
+
+## Installing the Chart
+
+To install the chart with the release name `codetogether-live`:
+
+```bash
+$ helm install codetogether-live -f codetogether-values.yaml ./codetogether-live
+```
+
+You can verify the deployment using:
+
+```bash
+$ helm list
+$ kubectl get all -n codetogether-live
+```
+
+## Updating the Chart
+
+To upgrade CodeTogether Live to a newer version:
+
+```bash
+$ helm repo update
+$ helm upgrade codetogether-live -f codetogether-values.yaml ./codetogether-live
+```
+
+## Uninstalling the Chart
+
+To uninstall the `codetogether-live` release:
+
+```bash
+$ helm uninstall codetogether-live


### PR DESCRIPTION
Added detailed README.md files for the following CodeTogether Helm charts:
- CodeTogether HQ
- CodeTogether Live
- CodeTogether Collab

Each README contains comprehensive configuration details, installation instructions, and usage guidelines tailored to the respective chart's `values.yaml` file.

These additions provide clear documentation for deploying and managing CodeTogether applications in Kubernetes environments.