### PR TITLE
feat: update Docker Compose file to rename codetogether-hq service to…

### DIFF
--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -1,7 +1,7 @@
-services: 
-  codetogether-hq:
-    image: hub.edge.codetogether.com/releases/codetogether-hq:latest
-    container_name: codetogether-hq
+services:
+  codetogether-intel:
+    image: hub.edge.codetogether.com/releases/codetogether-intel:latest
+    container_name: codetogether-intel
     environment:
       - CT_HQ_BASE_URL=https://your-hq-server-fqdn
     networks:


### PR DESCRIPTION
… codetogether-intel

- Renamed the service from `codetogether-hq` to `codetogether-intel`.
- Updated the container name to `codetogether-intel`.
- Changed the image to `hub.edge.codetogether.com/releases/codetogether-intel:latest`.
- Retained all existing configurations for compatibility.