### PR TITLE
fix(Live): indentation in deployment.yaml

### DIFF
--- a/charts/live/templates/deployment.yaml
+++ b/charts/live/templates/deployment.yaml
@@ -133,7 +133,7 @@ spec:
             value: {{ .Values.codetogether.timeZone.region | quote }}
           {{- end }}
 
-         - name: CT_LICENSEE
+          - name: CT_LICENSEE
             valueFrom:
               secretKeyRef:
                 name: {{ include "codetogether.fullname" . }}-license


### PR DESCRIPTION
Related to issue https://github.com/CodeTogether-Inc/CodeTogether-Deployment/issues/40

The deployment yaml has an incorrect indentation within the `env` property.

https://github.com/CodeTogether-Inc/CodeTogether-Deployment/blob/dev/charts/live/templates/deployment.yaml#L136

```
          {{- if .Values.codetogether.timeZone.enabled }}
          - name: CT_TIME_ZONE
            value: {{ .Values.codetogether.timeZone.region | quote }}
          {{- end }}

         - name: CT_LICENSEE
            valueFrom:
              secretKeyRef:
                name: {{ include "codetogether.fullname" . }}-license
                key: licensee
          - name: CT_MAXCONNECTIONS
            valueFrom:
              secretKeyRef:
                name: {{ include "codetogether.fullname" . }}-license
                key: max_connections
```

Which results in this error when `helm` generates the template:

```
Error: YAML parse error on codetogether/templates/deployment.yaml: error converting YAML to JSON: yaml: line 50: did not find expected '-' indicator

Use --debug flag to render out invalid YAML
```

This makes it impossible to run the helm chart without having to fork.  I have verified that fixing the indentation allows the template to be built.
I used `helm template live` to verify the fix.