### PR TITLE
Intel chart improvements: allow image digest & allow cassandra db password from secret

### DIFF
--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -31,9 +31,11 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: >-
+            {{ .Values.image.repository }}
+            {{- if .Values.image.digest }}@{{ .Values.image.digest }}
+            {{- else }}:{{ .Values.image.tag | default .Chart.AppVersion }}{{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
-
           env:
           #
           # Set CodeTogether runtime configuration

--- a/charts/intel/templates/secret-properties.yaml
+++ b/charts/intel/templates/secret-properties.yaml
@@ -6,5 +6,13 @@ type: Opaque
 stringData:
   cthq.properties: |-
     {{- range $key, $value := .Values.hqproperties }}
-       {{ $key }}={{ $value }}
+      {{- if eq $key "hq.cassandra.db.username" }}
+        {{- if .Values.cassandra.passwordSecret }}
+    {{ $key }}={{ include "cassandra.password" .Values.cassandra.passwordSecret }}
+        {{- else }}
+    {{ $key }}={{ $value }}
+        {{- end }}
+      {{- else }}
+    {{ $key }}={{ $value }}
+      {{- end }}
     {{- end }}

--- a/charts/intel/templates/secret-properties.yaml
+++ b/charts/intel/templates/secret-properties.yaml
@@ -7,8 +7,8 @@ stringData:
   cthq.properties: |-
     {{- range $key, $value := .Values.hqproperties }}
       {{- if eq $key "hq.cassandra.db.username" }}
-        {{- if .Values.cassandra.passwordSecret }}
-    {{ $key }}={{ include "cassandra.password" .Values.cassandra.passwordSecret }}
+        {{- if $.Values.cassandra.passwordSecret }}
+    {{ $key }}={{ include "cassandra.password" $.Values.cassandra.passwordSecret }}
         {{- else }}
     {{ $key }}={{ $value }}
         {{- end }}

--- a/charts/intel/templates/secret-properties.yaml
+++ b/charts/intel/templates/secret-properties.yaml
@@ -5,13 +5,13 @@ metadata:
 type: Opaque
 stringData:
   cthq.properties: |-
+    {{- $cassandraPassword := "" }}
+    {{- if and (hasKey .Values "cassandra") (hasKey .Values.cassandra "passwordSecret") .Values.cassandra.passwordSecret (lookup "v1" "Secret" .Release.Namespace .Values.cassandra.passwordSecret) }}
+    {{- $cassandraPassword := (lookup "v1" "Secret" .Release.Namespace .Values.cassandra.passwordSecret).data.cassandraPassword | b64dec }}
+    {{- end }}
     {{- range $key, $value := .Values.hqproperties }}
-      {{- if eq $key "hq.cassandra.db.username" }}
-        {{- if $.Values.cassandra.passwordSecret }}
-    {{ $key }}={{ (lookup "v1" "Secret" .Release.Namespace $.Values.cassandra.passwordSecret).data.cassandra.password | b64dec }}
-        {{- else }}
-    {{ $key }}={{ $value }}
-        {{- end }}
+      {{- if and (eq $key "hq.cassandra.db.password") $cassandraPassword }}
+    {{ $key }}={{ $cassandraPassword }}
       {{- else }}
     {{ $key }}={{ $value }}
       {{- end }}

--- a/charts/intel/templates/secret-properties.yaml
+++ b/charts/intel/templates/secret-properties.yaml
@@ -8,7 +8,7 @@ stringData:
     {{- range $key, $value := .Values.hqproperties }}
       {{- if eq $key "hq.cassandra.db.username" }}
         {{- if $.Values.cassandra.passwordSecret }}
-    {{ $key }}={{ include "cassandra.password" $.Values.cassandra.passwordSecret }}
+    {{ $key }}={{ (lookup "v1" "Secret" .Release.Namespace $.Values.cassandra.passwordSecret).data.cassandra.password | b64dec }}
         {{- else }}
     {{ $key }}={{ $value }}
         {{- end }}

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -15,6 +15,8 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
+  # Optional: specify a digest to use a specific image version, if provided will override the
+  digest: ""
 
 #
 # Configure the source location for the Docker image, using the
@@ -56,6 +58,12 @@ hqproperties:
   hq.collab.secret: SECRET3
   # default datacenter name is 'datacenter1'
   # hq.cassandra.db.localdatacenter: datacenter1
+
+# Optional property, if provided the value from the secret will be used as the cassandra DB password
+# This will overwrite the value in the hqproperties hq.cassandra.db.password
+# The secret must have a key named 'cassandra.password'
+cassandra:
+  passwordSecret: ""
 
 #
 # Enables and configures Ingress (default = Nginx). The className value can be used


### PR DESCRIPTION
Fixes #63

These changes were requested by Kessel run during our meeting.
1. Support image digest when creating the container, this would guarantee that even if the tag was updated, the image would stay the same.
2. Allow pulling in the cassandra db password from an external secret