### PR TITLE
feat(intel): Add support for mounting custom Java cacerts file

### DIFF
--- a/charts/intel/README.md
+++ b/charts/intel/README.md
@@ -80,6 +80,17 @@ To secure CodeTogether, you can add a `secret` that contains your TLS (Transport
 $ kubectl create secret tls codetogether-intel-tls --key <your-private-key-filename> --cert <your-certificate-filename>
 ```
 
+## CACERTS
+
+CodeTogether Intel now supports overriding the Java cacerts file using a Kubernetes Secret.
+
+```bash
+kubectl create secret generic custom-cacerts \
+  --from-file=cacerts=./cacerts \
+  -n codetogether-intel
+  ```
+
+
 ## Installing the Chart
 
 To install the chart with the release name `codetogether-intel`:
@@ -110,3 +121,4 @@ To uninstall the `codetogether-intel` release:
 
 ```bash
 $ helm uninstall codetogether-intel
+```

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -42,10 +42,19 @@ spec:
           #         
           - name: CT_HQ_BASE_URL
             value: {{ .Values.codetogether.url | quote }}
+
+          - name: JAVA_OPTS
+            value: "-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+
           volumeMounts:
             - name: properties-volume
               mountPath: /opt/codetogether/runtime/cthq.properties
               subPath: cthq.properties
+            - name: cacerts-volume
+              mountPath: /etc/ssl/certs/java/cacerts
+              subPath: cacerts
+              readOnly: true
+
           # 
           # Set container configuration
           #
@@ -80,6 +89,9 @@ spec:
         - name: properties-volume
           secret:
             secretName: {{ if .Values.fullnameOverride }}{{ .Values.fullnameOverride }}-hqproperties{{ else }}hqproperties{{ end }}
+        - name: cacerts-volume
+          secret:
+            secretName: custom-cacerts
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -44,16 +44,15 @@ spec:
             value: {{ .Values.codetogether.url | quote }}
 
           - name: JAVA_OPTS
-            value: "-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
+            value: "{{ if .Values.javaOptions.enabled }} -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword={{ .Values.javaOptions.trustStorePassword }} {{ end }}"
 
           volumeMounts:
             - name: properties-volume
               mountPath: /opt/codetogether/runtime/cthq.properties
               subPath: cthq.properties
-            - name: cacerts-volume
+            - name: java-cacerts
               mountPath: /etc/ssl/certs/java/cacerts
               subPath: cacerts
-              readOnly: true
 
           # 
           # Set container configuration
@@ -86,12 +85,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
-        - name: properties-volume
+        - name: java-cacerts
           secret:
-            secretName: {{ if .Values.fullnameOverride }}{{ .Values.fullnameOverride }}-hqproperties{{ else }}hqproperties{{ end }}
-        - name: cacerts-volume
-          secret:
-            secretName: custom-cacerts
+            secretName: java-cacerts
+            optional: true  # Ensures deployment works even if the secret isn't provided
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -50,9 +50,11 @@ spec:
             - name: properties-volume
               mountPath: /opt/codetogether/runtime/cthq.properties
               subPath: cthq.properties
+            {{- if .Values.enableCustomCACerts }}
             - name: java-cacerts
               mountPath: /etc/ssl/certs/java/cacerts
               subPath: cacerts
+            {{- end }}
 
           # 
           # Set container configuration
@@ -85,10 +87,11 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
+        {{- if .Values.enableCustomCACerts }}
         - name: java-cacerts
           secret:
-            secretName: java-cacerts
-            optional: true  # Ensures deployment works even if the secret isn't provided
+            secretName: {{ .Values.cacertsSecretName }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -61,10 +61,24 @@ hqproperties:
 
   # Java configuration
 
-javaOptions:
-  enabled: true
-  trustStorePath: "/etc/ssl/certs/java/cacerts"
-  trustStorePassword: "changeit"  # This should be configurable by the user
+#
+# Enable optional Java CACerts replacement.
+# If set to `true`, a custom `cacerts` file will be mounted as a Kubernetes secret.
+#
+enableCustomCACerts: false
+
+#
+# Name of the secret containing the custom cacerts file.
+# Ensure the secret is created before deployment:
+# kubectl create secret generic custom-java-cacerts --from-file=cacerts=/path/to/custom/cacerts
+#
+cacertsSecretName: "custom-java-cacerts"
+
+#
+# Java options for SSL configuration.
+# If `enableCustomCACerts` is true, these options will be set automatically.
+#
+javaOptions: "-Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts -Djavax.net.ssl.trustStorePassword=changeit"
 
 # Secrets for mounting certificates
 secrets:

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -109,6 +109,18 @@ securityContext: {}
   # runAsNonRoot: true
   # runAsUser: 1000
 
+volumes:
+  - name: cacerts-volume
+    secret:
+      secretName: custom-cacerts
+
+volumeMounts:
+  - name: cacerts-volume
+    mountPath: /etc/ssl/certs/java/cacerts
+    subPath: cacerts
+    readOnly: true
+
+
 readinessProbe:
   initialDelaySeconds: 60
   periodSeconds: 60

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -59,6 +59,19 @@ hqproperties:
   # default datacenter name is 'datacenter1'
   # hq.cassandra.db.localdatacenter: datacenter1
 
+  # Java configuration
+
+javaOptions:
+  enabled: true
+  trustStorePath: "/etc/ssl/certs/java/cacerts"
+  trustStorePassword: "changeit"  # This should be configurable by the user
+
+# Secrets for mounting certificates
+secrets:
+  cacerts:
+    name: "codetogether-intel-cacerts"
+    key: "cacerts"
+
 # Optional property, if provided the value from the secret will be used as the cassandra DB password
 # This will overwrite the value in the hqproperties hq.cassandra.db.password
 # The secret must have a key named 'cassandra.password'
@@ -108,18 +121,6 @@ securityContext: {}
   # readOnlyRootFilesystem: true
   # runAsNonRoot: true
   # runAsUser: 1000
-
-volumes:
-  - name: cacerts-volume
-    secret:
-      secretName: custom-cacerts
-
-volumeMounts:
-  - name: cacerts-volume
-    mountPath: /etc/ssl/certs/java/cacerts
-    subPath: cacerts
-    readOnly: true
-
 
 readinessProbe:
   initialDelaySeconds: 60


### PR DESCRIPTION
- Introduced support for overriding the Java `cacerts` file in the Intel container
- Added `securityContext.cacerts.secretName` and `securityContext.cacerts.mountPath` to `values.yaml`
- Updated `deployment.yaml` to mount `cacerts` from a Kubernetes Secret
- Documented the setup process in `README.md`, including steps to create and mount the secret
- Ensured compatibility with existing Helm configurations

This allows users to inject custom CA certificates for trusted communication in the Intel container.
