### PR TITLE
feat: support for customization of java options and cacerts

### DIFF
--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -42,10 +42,42 @@ spec:
           #         
           - name: CT_HQ_BASE_URL
             value: {{ .Values.codetogether.url | quote }}
+
+          - name: CT_TRUSTSTORE_OPTIONS
+            value: >-
+              {{- if .Values.java.customCacerts.enabled }} 
+              -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts 
+              {{- end }} 
+              {{- if and .Values.java.customCacerts.enabled .Values.java.customCacerts.trustStorePasswordKey }}
+              -Djavax.net.ssl.trustStorePassword=${TRUST_STORE_PASSWORD}
+              {{- end }}
+
+          # Custom Java options (excluding trust store related settings)
+          {{- if .Values.java.customJavaOptions }} 
+          - name: CT_JAVA_OPTIONS
+            value: "{{ .Values.java.customJavaOptions | default "" }}"
+          {{- end }}
+
+          # Set trust store password only if trustStorePasswordKey is provided
+          {{- if and .Values.java.customCacerts.enabled .Values.java.customCacerts.trustStorePasswordKey }}
+          - name: TRUST_STORE_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: {{ .Values.java.customCacerts.cacertsSecretName }}
+                key: {{ .Values.java.customCacerts.trustStorePasswordKey }}
+                optional: true  # Ensures the key is optional
+          {{- end }}
+
           volumeMounts:
             - name: properties-volume
               mountPath: /opt/codetogether/runtime/cthq.properties
               subPath: cthq.properties
+            {{- if .Values.java.customCacerts.enabled }}
+            - name: java-cacerts
+              mountPath: /etc/ssl/certs/java/cacerts
+              subPath: cacerts
+            {{- end }}
+
           # 
           # Set container configuration
           #
@@ -80,6 +112,11 @@ spec:
         - name: properties-volume
           secret:
             secretName: {{ if .Values.fullnameOverride }}{{ .Values.fullnameOverride }}-hqproperties{{ else }}hqproperties{{ end }}
+        {{- if .Values.java.customCacerts.enabled }}
+        - name: java-cacerts
+          secret:
+            secretName: {{ .Values.java.customCacerts.cacertsSecretName }}
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -49,7 +49,7 @@ spec:
               -Djavax.net.ssl.trustStore=/etc/ssl/certs/java/cacerts 
               {{- end }} 
               {{- if and .Values.java.customCacerts.enabled .Values.java.customCacerts.trustStorePasswordKey }}
-              -Djavax.net.ssl.trustStorePassword=${TRUST_STORE_PASSWORD}
+              -Djavax.net.ssl.trustStorePassword=$(TRUST_STORE_PASSWORD)
               {{- end }}
 
           # Custom Java options (excluding trust store related settings)

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -65,6 +65,36 @@ hqproperties:
 cassandra:
   passwordSecret: ""
 
+java:
+  customCacerts:
+    enabled: false  # Set to 'true' to enable custom Java trust store (cacerts) support.
+
+    # Name of the Kubernetes secret that contains the custom Java trust store (cacerts) file.
+    # This secret should be created before deploying the application using:
+    #   kubectl create secret generic custom-java-cacerts \
+    #     --from-file=cacerts=/path/to/custom/cacerts
+    #
+    # If a password is required for the trust store, it can optionally be added to the same secret (see below).
+    #
+    # The 'cacerts' file is mounted to the container at '/etc/ssl/certs/java/cacerts'.
+    cacertsSecretName: "custom-java-cacerts"
+
+    # (Optional) The key inside the Kubernetes secret that holds the trust store password.
+    # If a password is required for the custom trust store, store it in the same secret as a key-value pair:
+    #   kubectl create secret generic custom-java-cacerts \
+    #     --from-file=cacerts=/path/to/custom/cacerts \
+    #     --from-literal=trustStorePassword='your-secure-password'
+    #
+    # If this key is not present in the secret, no trust store password will be set.
+    # trustStorePasswordKey: "trustStorePassword"
+
+  # Additional custom Java options to be passed to the application.
+  # These options will be appended to the CT_JAVA_OPTIONS environment variable.
+  #
+  # Example:
+  # customJavaOptions: "-Xms512m -Xmx2g -XX:+UseG1GC"
+  customJavaOptions: ""
+
 #
 # Enables and configures Ingress (default = Nginx). The className value can be used
 # to change the default behavior. Please read the comments below to see details.


### PR DESCRIPTION
Fixes #66

### Changes in this PR:

- Support for passing custom java options to backend start script.
- Support customization of the cacerts (with optional password) from the secret.