### PR TITLE
fix: remove k8s version constraint from the readme

### DIFF
--- a/charts/intel/README.md
+++ b/charts/intel/README.md
@@ -10,7 +10,6 @@ This chart creates a CodeTogether Intel server deployment on a Kubernetes cluste
 
 This chart has been created with Helm v3 and tested with:
 
-- Kubernetes v1.18+
 - Helm v3.5+
 - Cassandra v3.11+
 


### PR DESCRIPTION
Fixes #57 

### Changes in this PR:

- Update readme.md to do not include minimal k8s verison.