### PR TITLE
Enable skipping upload of previously uploaded charts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: azure/setup-helm@v3
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.5.0
+        uses: helm/chart-releaser-action@v1.7.0
         with:
           skip_existing: true
         env:


### PR DESCRIPTION
bump version of chart-releaser-action so that we can skip existing chart versions that are already uploaded