### PR TITLE
Allow user to provide their own hqproperties secret

### DIFF
--- a/charts/intel/README.md
+++ b/charts/intel/README.md
@@ -31,7 +31,8 @@ The following table lists configurable parameters of the CodeTogether Intel char
 | `imageCredentials.password`                    | Docker registry password                                                                     | `my-customer-password`                                    |
 | `imageCredentials.email`                       | Docker registry email                                                                        | `unused`                                                  |
 | `codetogether.url`                             | Full URL for the CodeTogether Intel server                                                     | `https://<server-fqdn>`                                   |
-| `hqproperties.secretRef`                     | (Optional) Name of a Kubernetes secret containing the hqproperties secret. If provided, will override the other values in the hqproperties section     | `kubernetes-secret-name` |
+| `hqpropertiessecret.enabled`                     | (Optional) If true, the value in hqpropertiessecret.ref will be used in place of the hqproperties values     | `false` |
+| `hqpropertiessecret.ref`                     | (Optional) Name of a Kubernetes secret containing the hqproperties secret. If provided, will override the other values in the hqproperties section     | `kubernetes-secret-name` |
 | `hqproperties.hq.sso.client.id`                | Client ID for Single Sign-On (SSO)                                                          | `CLIENTID.apps.googleusercontent.com`                     |
 | `hqproperties.hq.sso.client.secret`            | Client Secret for Single Sign-On (SSO)                                                      | `CLIENTSECRET`                                            |
 | `hqproperties.hq.sso.client.issuer.url`        | Issuer URL for Single Sign-On (SSO)                                                         | `https://accounts.google.com`                             |

--- a/charts/intel/README.md
+++ b/charts/intel/README.md
@@ -31,6 +31,7 @@ The following table lists configurable parameters of the CodeTogether Intel char
 | `imageCredentials.password`                    | Docker registry password                                                                     | `my-customer-password`                                    |
 | `imageCredentials.email`                       | Docker registry email                                                                        | `unused`                                                  |
 | `codetogether.url`                             | Full URL for the CodeTogether Intel server                                                     | `https://<server-fqdn>`                                   |
+| `hqproperties.secretRef`                     | (Optional) Name of a Kubernetes secret containing the hqproperties secret. If provided, will override the other values in the hqproperties section     | `kubernetes-secret-name` |
 | `hqproperties.hq.sso.client.id`                | Client ID for Single Sign-On (SSO)                                                          | `CLIENTID.apps.googleusercontent.com`                     |
 | `hqproperties.hq.sso.client.secret`            | Client Secret for Single Sign-On (SSO)                                                      | `CLIENTSECRET`                                            |
 | `hqproperties.hq.sso.client.issuer.url`        | Issuer URL for Single Sign-On (SSO)                                                         | `https://accounts.google.com`                             |
@@ -51,7 +52,6 @@ The following table lists configurable parameters of the CodeTogether Intel char
 | `java.customCacerts.enabled`                   | Enables mounting a custom Java trust store (cacerts)                                         | `false`                                                  |
 | `java.customCacerts.cacertsSecretName`         | Name of the Kubernetes secret containing the `cacerts` file                                  | `custom-java-cacerts`                                    |
 | `java.customCacerts.trustStorePasswordKey`     | (Optional) Key inside the Kubernetes secret containing the trust store password             | `trustStorePassword`                                     |
-| `cassandra.passwordSecret`                     | (Optional) Name of a Kubernetes secret containing the Cassandra database password.          |                                                           |
 | `ingress.enabled`                              | Enables ingress controller resource                                                         | `true`                                                    |
 | `ingress.annotations`                          | Annotations for ingress                                                                      | `{}`                                                      |
 | `ingress.tls.secretName`                       | TLS secret name for ingress                                                                 | `codetogether-intel-tls`                                     |

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -107,8 +107,8 @@ spec:
       volumes:
         - name: properties-volume
           secret:
-            secretName: {{- if .Values.hqproperties.secretRef }}
-              {{- .Values.hqproperties.secretRef }}
+            secretName: {{- if .Values.hqpropertiessecret.enabled }}
+              {{- .Values.hqpropertiessecret.ref }}
             {{- else if .Values.fullnameOverride }}
               {{- printf "%s-hqproperties" .Values.fullnameOverride }}
             {{- else }}

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -107,7 +107,13 @@ spec:
       volumes:
         - name: properties-volume
           secret:
-            secretName: {{ if .Values.fullnameOverride }}{{ .Values.fullnameOverride }}-hqproperties{{ else }}hqproperties{{ end }}
+            secretName: {{- if .Values.hqproperties.secretRef }}
+              {{- .Values.hqproperties.secretRef }}
+            {{- else if .Values.fullnameOverride }}
+              {{- printf "%s-hqproperties" .Values.fullnameOverride }}
+            {{- else }}
+              {{- "hqproperties" }}
+            {{- end }}
         {{- if .Values.java.customCacerts.enabled }}
         - name: java-cacerts
           secret:

--- a/charts/intel/templates/secret-properties.yaml
+++ b/charts/intel/templates/secret-properties.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.hqproperties.secretRef }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -5,14 +6,7 @@ metadata:
 type: Opaque
 stringData:
   cthq.properties: |-
-    {{- $cassandraPassword := "" }}
-    {{- if and (hasKey .Values "cassandra") (hasKey .Values.cassandra "passwordSecret") .Values.cassandra.passwordSecret (lookup "v1" "Secret" .Release.Namespace .Values.cassandra.passwordSecret) }}
-    {{- $cassandraPassword := (lookup "v1" "Secret" .Release.Namespace .Values.cassandra.passwordSecret).data.cassandraPassword | b64dec }}
-    {{- end }}
     {{- range $key, $value := .Values.hqproperties }}
-      {{- if and (eq $key "hq.cassandra.db.password") $cassandraPassword }}
-    {{ $key }}={{ $cassandraPassword }}
-      {{- else }}
-    {{ $key }}={{ $value }}
-      {{- end }}
+       {{ $key }}={{ $value }}
     {{- end }}
+{{- end }}

--- a/charts/intel/templates/secret-properties.yaml
+++ b/charts/intel/templates/secret-properties.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.hqproperties.secretRef }}
+{{- if not .Values.hqpropertiessecret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -40,6 +40,8 @@ codetogether:
   url: https://<server-fqdn>
 
 hqproperties:
+  # Optional property, if provided the value from the secret will be used as the hqproperties secret
+  secretRef: ""
   hq.sso.client.id: CLIENTID.apps.googleusercontent.com
   hq.sso.client.secret: CLIENTSECRET
   hq.sso.client.issuer.url: https://accounts.google.com
@@ -58,12 +60,6 @@ hqproperties:
   hq.collab.secret: SECRET3
   # default datacenter name is 'datacenter1'
   # hq.cassandra.db.localdatacenter: datacenter1
-
-# Optional property, if provided the value from the secret will be used as the cassandra DB password
-# This will overwrite the value in the hqproperties hq.cassandra.db.password
-# The secret must have a key named 'cassandraPassword'
-cassandra:
-  passwordSecret: ""
 
 java:
   customCacerts:

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -40,8 +40,6 @@ codetogether:
   url: https://<server-fqdn>
 
 hqproperties:
-  # Optional property, if provided the value from the secret will be used as the hqproperties secret
-  secretRef: ""
   hq.sso.client.id: CLIENTID.apps.googleusercontent.com
   hq.sso.client.secret: CLIENTSECRET
   hq.sso.client.issuer.url: https://accounts.google.com
@@ -60,6 +58,11 @@ hqproperties:
   hq.collab.secret: SECRET3
   # default datacenter name is 'datacenter1'
   # hq.cassandra.db.localdatacenter: datacenter1
+
+# Optional properties, if enabled is true, the values in the secret will be used as the hqproperties secret
+hqpropertiessecret:
+  enabled: false
+  ref: "intel-test-hqproperties-arbitrary"
 
 java:
   customCacerts:


### PR DESCRIPTION
### Summary: allow users to provide their own hqproperties secret for improved security over sensitive information.

### New values introduced:
hqpropertiessecret.enabled, a boolean as to whether an external secret should be referenced
hqpropertiessecret.ref: the name of a kubernetes string in the same namespace that contains the values for hqproperties

### Detailed explanation
because hqproperties contains sensitive information, users may wish to provide their own hqproperties secret.
this secret will need to exist in the same namespace as the intel deployment.
it must contain a key `cthq.properties` that contains a base64 encoded value that contains all the required keys mentioned in the values file