### PR TITLE
fix(intel-chart): handle nil ai.openai.api_key to prevent template er…

### DIFF
--- a/charts/intel/templates/secrets.yaml
+++ b/charts/intel/templates/secrets.yaml
@@ -4,9 +4,13 @@ metadata:
   name: ai-secrets
 type: Opaque
 data:
-  {{- if and (.Values.ai.openai) (.Values.ai.openai.api_key) }}
+  {{- if .Values.ai.openai }}
+  {{- if .Values.ai.openai.api_key }}
   openai-api-key: {{ .Values.ai.openai.api_key | b64enc }}
   {{- end }}
-  {{- if and (.Values.ai.external) (.Values.ai.external.api_key) }}
+  {{- end }}
+  {{- if .Values.ai.external }}
+  {{- if .Values.ai.external.api_key }}
   external-ai-key: {{ .Values.ai.external.api_key | b64enc }}
+  {{- end }}
   {{- end }}

--- a/charts/intel/templates/secrets.yaml
+++ b/charts/intel/templates/secrets.yaml
@@ -4,5 +4,9 @@ metadata:
   name: ai-secrets
 type: Opaque
 data:
+  {{- if and (.Values.ai.openai) (.Values.ai.openai.api_key) }}
   openai-api-key: {{ .Values.ai.openai.api_key | b64enc }}
+  {{- end }}
+  {{- if and (.Values.ai.external) (.Values.ai.external.api_key) }}
   external-ai-key: {{ .Values.ai.external.api_key | b64enc }}
+  {{- end }}


### PR DESCRIPTION
…rors

Adjusted the Helm chart template for ai-secrets to avoid referencing ai.openai.api_key and ai.external.api_key when undefined.
This fixes a fatal error during `helm template` when AI mode is set to `bundled` and no OpenAI config is present. Ensures compatibility with bundled-only deployments. #115 