### PR TITLE
feat(intel): add option to disable AI integration entirely

### DIFF
--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -28,21 +28,23 @@ spec:
       {{- end }}
       serviceAccountName: {{ include "codetogether.serviceAccountName" . }}
       containers:
-        {{- if eq .Values.ai.mode "bundled" }}
-        - name: codetogether-llm
-          image: "{{ .Values.ai.image.repository }}:{{ .Values.ai.image.tag }}"
-          imagePullPolicy: Always
-          ports:
-            - name: ai
-              containerPort: 8000
-              protocol: TCP
-          resources:
-            requests:
-              cpu: {{ .Values.ai.resources.requests.cpu | quote }}
-              memory: {{ .Values.ai.resources.requests.memory | quote }}
-            limits:
-              cpu: {{ .Values.ai.resources.limits.cpu | quote }}
-              memory: {{ .Values.ai.resources.limits.memory | quote }}
+        {{- if .Values.ai.enabled }}
+          {{- if eq .Values.ai.mode "bundled" }}
+          - name: codetogether-llm
+            image: "{{ .Values.ai.image.repository }}:{{ .Values.ai.image.tag }}"
+            imagePullPolicy: Always
+            ports:
+              - name: ai
+                containerPort: 8000
+                protocol: TCP
+            resources:
+              requests:
+                cpu: {{ .Values.ai.resources.requests.cpu | quote }}
+                memory: {{ .Values.ai.resources.requests.memory | quote }}
+              limits:
+                cpu: {{ .Values.ai.resources.limits.cpu | quote }}
+                memory: {{ .Values.ai.resources.limits.memory | quote }}
+          {{- end }}
         {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
@@ -56,22 +58,24 @@ spec:
           - name: AI_BUNDLED_URL
             value: "http://codetogether-llm:8000"
           {{- end }}
-          {{- if eq .Values.ai.mode "external" }}
-          - name: AI_PROVIDER
-            valueFrom:
-              configMapKeyRef:
-                name: ai-config
-                key: ai_provider
-          - name: AI_EXTERNAL_URL
-            valueFrom:
-              configMapKeyRef:
-                name: ai-config
-                key: ai_url
-          - name: AI_EXTERNAL_API_KEY
-            valueFrom:
-              secretKeyRef:
-                name: ai-external-secret
-                key: api-key
+          {{- if .Values.ai.enabled }}
+            {{- if eq .Values.ai.mode "external" }}
+            - name: AI_PROVIDER
+              valueFrom:
+                configMapKeyRef:
+                  name: ai-config
+                  key: ai_provider
+            - name: AI_EXTERNAL_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: ai-config
+                  key: ai_url
+            - name: AI_EXTERNAL_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: ai-external-secret
+                  key: api-key
+            {{- end }}
           {{- end }}
           #
           # Set CodeTogether runtime configuration

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -139,6 +139,7 @@ securityContext: {}
   # runAsUser: 1000
 
 ai:
+  enabled: false
   mode: "bundled"  # Options: bundled | external
   provider: "ollama"  # No OpenAI dependency
   resources:


### PR DESCRIPTION
Previously, the Helm chart required either 'bundled' or 'external' AI mode to be configured, making it mandatory to include AI integration. This commit introduces a new flag `ai.enabled` to allow disabling AI features entirely, enabling Intel to be deployed without any AI-related containers or resources.