### PR TITLE
fix: update LLM image URL to hub.edge

### DIFF
--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -142,6 +142,9 @@ ai:
   enabled: false
   mode: "bundled"  # Options: bundled | external
   provider: "ollama"  # No OpenAI dependency
+  image:
+    repository: hub.edge.codetogether.com/releases/codetogether-llm
+    tag: latest
   resources:
     requests:
       cpu: "2"
@@ -151,10 +154,6 @@ ai:
       cpu: "4"
       memory: "8Gi"
       gpu: false
-  image:
-    repository: registry.digitalocean.com/codetogether-registry/codetogether-llm
-    tag: latest
-
 
 readinessProbe:
   initialDelaySeconds: 60


### PR DESCRIPTION
This PR updates the repository URL for the codetogether-llm image in the values.yaml so that it pulls from hub.edge.codetogether.com.

Fixes #125 

### Changes

In values.yaml under the LLM provider section:

Changed image.repository to hub.edge.codetogether.com/releases/codetogether-llm

Left tag: latest as-is

No other values were modified

### Dev Testing

Enable ai mode:

```
ai:
  enabled: true
  mode: "bundled"
```

Install/upgrade the Helm release:

`helm install intel-test codetogether/codetogether-intel   --namespace "namespace_name"   -f values.yaml`

Verify in the cluster that the codetogether-llm pod is recreating and pulling from the new registry:

```
kubectl get pods -n "namespace_name" -l app=codetogether-llm
kubectl describe pod -n "namespace_name" <pod-name> | grep Image
```

Confirm the image reference:

```
kubectl get deployment codetogether-llm -n "namespace_name" -o yaml \
  | grep "hub.edge.codetogether.com/releases/codetogether-llm"
```