### PR TITLE
fix(ai): incorrect GPU resource format in values.yaml, support bundle…

### DIFF
--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -40,6 +40,7 @@ spec:
             - name: AI_BUNDLED_URL
               value: "http://codetogether-llm:8000"
             {{- end }}
+
             {{- if .Values.ai.enabled }}
               {{- if eq .Values.ai.mode "external" }}
             - name: AI_PROVIDER
@@ -78,6 +79,22 @@ spec:
                   key: {{ .Values.java.customCacerts.trustStorePasswordKey }}
                   optional: true
             {{- end }}
+            {{- if .Values.ai.enabled }}
+            - name: CT_HQ_OLLAMA_AI_URL
+              value: {{ if eq .Values.ai.mode "bundled" }}"http://localhost:8000"{{ else }}"{{ .Values.ai.url | quote }}"{{ end }}
+            - name: CT_HQ_OLLAMA_AI_MODEL_NAME
+              value: {{ .Values.ai.modelName | default "gemma3:1b" | quote }}
+            - name: CT_HQ_OLLAMA_AI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{- if and (eq .Values.ai.mode "external") (not .Values.ai.externalSecret.create) }}
+                    {{ .Values.ai.externalSecret.name }}
+                  {{- else }}
+                    {{ .Values.ai.externalSecret.name | default (printf "%s-ollama-api" .Release.Name) }}
+                  {{- end }}
+                  key: apiKey
+            {{- end }}
+
 
           volumeMounts:
             - name: properties-volume

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -148,11 +148,11 @@ ai:
     requests:
       cpu: "2"
       memory: "4Gi"
-      gpu: false
+      # gpu: "1"   # Uncomment and set only if GPU is needed
     limits:
       cpu: "4"
       memory: "4Gi"
-      gpu: false
+      # gpu: "1"
 
 readinessProbe:
   initialDelaySeconds: 60


### PR DESCRIPTION
Fixes #136 

- Added support for setting CT_HQ_OLLAMA_AI_API_KEY, CT_HQ_OLLAMA_AI_URL, and CT_HQ_OLLAMA_AI_MODEL_NAME env vars in deployment.yaml
- Resolved an issue with incorrect GPU resource format in values.yaml (`gpu: false` is now removed or properly set as a quantity like `gpu: "1"` when needed)