### PR TITLE
feat(charts, compose): add CT_TRUST_ALL_CERTS support

### DIFF
--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -76,7 +76,7 @@ spec:
                   key: {{ .Values.java.customCacerts.trustStorePasswordKey }}
                   optional: true
             {{- end }}
-            {{- if .Values.java.trustAllCerts }}
+            {{- if .Values.codetogether.trustAllCerts }}
             - name: CT_TRUST_ALL_CERTS
               value: "true"
             {{- end }}

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -76,6 +76,10 @@ spec:
                   key: {{ .Values.java.customCacerts.trustStorePasswordKey }}
                   optional: true
             {{- end }}
+            {{- if .Values.java.trustAllCerts }}
+            - name: CT_TRUST_ALL_CERTS
+              value: "true"
+            {{- end }}
             {{- if .Values.ai.enabled }}
             - name: CT_HQ_OLLAMA_AI_URL
               value: {{ if eq .Values.ai.mode "bundled" }}

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -93,6 +93,7 @@ java:
   # Example:
   # customJavaOptions: "-Xms512m -Xmx2g -XX:+UseG1GC"
   customJavaOptions: ""
+  trusstAllCerts: false  # Set to 'true' to trust all certificates
 
 #
 # Enables and configures Ingress (default = Nginx). The className value can be used

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -38,6 +38,8 @@ imageCredentials:
 #
 codetogether:
   url: https://<server-fqdn>
+  trustAllCerts: false  # Set to 'true' to trust all certificates
+
 
 hqproperties:
   hq.sso.client.id: CLIENTID.apps.googleusercontent.com
@@ -93,7 +95,6 @@ java:
   # Example:
   # customJavaOptions: "-Xms512m -Xmx2g -XX:+UseG1GC"
   customJavaOptions: ""
-  trusstAllCerts: false  # Set to 'true' to trust all certificates
 
 #
 # Enables and configures Ingress (default = Nginx). The className value can be used

--- a/compose/.env-template
+++ b/compose/.env-template
@@ -51,3 +51,7 @@ DHPARAM_PEM=dhparam.pem
 # Uncomment the following lines to enable AI integration with Ollama
 #CT_HQ_OLLAMA_AI_URL=http://codetogether-llm:8000
 #CT_HQ_OLLAMA_AI_MODEL_NAME=gemma3:1b
+
+# Enable “to trust all certificates”
+CT_TRUST_ALL_CERTS=false
+

--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -42,7 +42,6 @@ services:
       - .env
     environment:
       - CT_HQ_BASE_URL=https://${INTEL_FQDN}
-      - CT_TRUST_ALL_CERTS=${CT_TRUST_ALL_CERTS}
     networks:
       - codetogethernet
     volumes:

--- a/compose/compose.yaml
+++ b/compose/compose.yaml
@@ -42,6 +42,7 @@ services:
       - .env
     environment:
       - CT_HQ_BASE_URL=https://${INTEL_FQDN}
+      - CT_TRUST_ALL_CERTS=${CT_TRUST_ALL_CERTS}
     networks:
       - codetogethernet
     volumes:


### PR DESCRIPTION
Fixes: #157
- values.yaml: introduce `java.trustAllCerts` (default false) to toggle CT_TRUST_ALL_CERTS
- deployment.yaml: inject `CT_TRUST_ALL_CERTS=true` into container env when `trustAllCerts` is enabled
- .env-template: add `CT_TRUST_ALL_CERTS` entry for Docker Compose
- compose.yml: reference `${CT_TRUST_ALL_CERTS}` in codetogether‑intel service