### PR TITLE
feat(chart): guard `ai-secrets` template behind `ai.enabled`

### DIFF
--- a/charts/intel/templates/secrets.yaml
+++ b/charts/intel/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.ai.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -14,3 +15,4 @@ data:
   external-ai-key: {{ .Values.ai.external.api_key | b64enc }}
   {{- end }}
   {{- end }}
+{{- end }}


### PR DESCRIPTION
Fixes: #160

Wrap the `ai-secrets` Secret manifest with a `.Values.ai.enabled` conditional so it is not rendered when AI is disabled. This prevents clashes with pre-existing `ai-secrets` owned by other releases and keeps templates clean.