### PR TITLE
fix(helm/intel): scope AI resources per-release to avoid cross-releas…

### DIFF
--- a/charts/intel/templates/ai-config.yaml
+++ b/charts/intel/templates/ai-config.yaml
@@ -2,10 +2,13 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: ai-config
+  name: {{ printf "%s-ai-config" (include "codetogether.fullname" .) }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "codetogether.labels" . | nindent 4 }}
 data:
   ai_provider: {{ .Values.ai.provider | quote }}
   ai_url: {{ .Values.ai.url | quote }}
 {{- end }}
+
 

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -44,12 +44,12 @@ spec:
             - name: AI_PROVIDER
               valueFrom:
                 configMapKeyRef:
-                  name: ai-config
+                  name: {{ printf "%s-ai-config" (include "codetogether.fullname" .) }}
                   key: ai_provider
             - name: AI_EXTERNAL_URL
               valueFrom:
                 configMapKeyRef:
-                  name: ai-config
+                  name: {{ printf "%s-ai-config" (include "codetogether.fullname" .) }}
                   key: ai_url
             - name: AI_EXTERNAL_API_KEY
               valueFrom:

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -143,9 +143,13 @@ securityContext: {}
 ai:
   enabled: false
   mode: "bundled"  # Options: bundled | external
-  image:
-    repository: hub.edge.codetogether.com/releases/codetogether-llm
-    tag: latest
+  provider: ""
+  url: ""
+  modelName: "gemma3:1b"
+  externalSecret:
+    create: false
+    name: ""
+    apiKey: ""
 #  resources:       # Recommended resources configuration
  #   requests:
   #    cpu: "2"


### PR DESCRIPTION
…e Secret conflicts

Fixes: #163

Problem
- Deploying multiple `codetogether-intel` releases in the same namespace caused a collision on statically named resources (e.g., `ai-secrets` / `ai-config`), producing Helm ownership errors.

What changed
- templates/ai-config.yaml
  - Create ConfigMap only when `ai.enabled=true` and `ai.mode=external`.
  - Name is now release-scoped: `{{ .Release.Name }}-ai-config`.

- templates/ai-external-secret.yaml
  - Respect `ai.externalSecret.create` and `ai.externalSecret.name`.
  - Default Secret name is release-scoped: `{{ include "codetogether.fullname" . }}-ai-external-secret`.
  - Store API key under `stringData.apiKey`.

- templates/deployment.yaml
  - Read `AI_PROVIDER` / `AI_EXTERNAL_URL` from `{{ .Release.Name }}-ai-config`.
  - Read `AI_EXTERNAL_API_KEY` from the default or user-specified Secret: `{{ default (printf "%s-ai-external-secret" (include "codetogether.fullname" .)) .Values.ai.externalSecret.name }}`.
  - Bundled mode unchanged; external resources are not created in bundled mode.

Why
- Ensures two or more releases (e.g., `qa-intel` and `demo-staging-intel`) can coexist in the same namespace without Helm ownership clashes.

How to test
- External (chart-managed Secret): `helm template demo-staging-intel ./charts/intel -n default \ --set ai.enabled=true --set ai.mode=external \ --set ai.provider=openai --set ai.url=https://api.openai.com \ --set ai.externalSecret.create=true --set ai.externalSecret.apiKey=TESTKEY` → renders `demo-staging-intel-ai-config` and `demo-staging-intel-ai-external-secret`.

- External (existing Secret): `kubectl create secret generic my-custom-ai-secret -n default \ --from-literal=apiKey=TESTKEY` `helm template qa-intel ./charts/intel -n default \ --set ai.enabled=true --set ai.mode=external \ --set ai.provider=openai --set ai.url=https://api.openai.com \ --set ai.externalSecret.create=false --set ai.externalSecret.name=my-custom-ai-secret` → renders only the release-scoped ConfigMap; Deployment references the existing Secret.

- Bundled: `helm template demo ./charts/intel -n default --set ai.enabled=true --set ai.mode=bundled` → no AI ConfigMap/Secret rendered; sidecar included.