### PR TITLE
feat(helm-collab): Support optional existing secret for Intel connection

### DIFF
--- a/charts/collab/templates/deployment.yaml
+++ b/charts/collab/templates/deployment.yaml
@@ -13,7 +13,7 @@ spec:
       annotations:
         checksum/coturn: {{ include (print $.Template.BasePath "/secret-coturn.yaml") . | sha256sum }}
         checksum/dashboard: {{ include (print $.Template.BasePath "/secret-dashboard.yaml") . | sha256sum }}
-        checksum/intel: {{ include (print $.Template.BasePath "/secret-intel.yaml") . | sha256sum }}
+        checksum/intel: {{- if not .Values.intelsecret.enabled }} {{ include (print $.Template.BasePath "/secret-intel.yaml") . | sha256sum }} {{- else }} "external" {{- end }}
         checksum/ssl: {{ include (print $.Template.BasePath "/secret-ssl.yaml") . | sha256sum }}
       {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
@@ -139,15 +139,27 @@ spec:
             value: {{ .Values.codetogether.timeZone.region | quote }}
           {{- end }}
 
+          {{- if and .Values.intelsecret.enabled (not .Values.intelsecret.ref) }}
+          {{- fail "intelsecret.enabled=true requires intelsecret.ref (existing Secret name)" -}}
+          {{- end }}
+
           - name: CT_INTEL_URL
             valueFrom:
               secretKeyRef:
-                name: {{ include "codetogether.fullname" . }}-intel
+                name: {{ if .Values.intelsecret.enabled -}}
+                        {{ .Values.intelsecret.ref | quote }}
+                      {{- else }}
+                        {{ printf "%s-intel" (include "codetogether.fullname" .) | quote }}
+                      {{- end }}
                 key: url
           - name: CT_INTEL_SECRET
             valueFrom:
               secretKeyRef:
-                name: {{ include "codetogether.fullname" . }}-intel
+                name: {{ if .Values.intelsecret.enabled -}}
+                        {{ .Values.intelsecret.ref | quote }}
+                      {{- else }}
+                        {{ printf "%s-intel" (include "codetogether.fullname" .) | quote }}
+                      {{- end }}
                 key: secret
           {{- if .Values.dashboard.enabled }}
           - name: CT_DASHBOARD_USER

--- a/charts/collab/templates/secret-intel.yaml
+++ b/charts/collab/templates/secret-intel.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.intelsecret.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,3 +9,4 @@ type: Opaque
 data:
   url: {{ .Values.intel.url | b64enc | quote }}
   secret: {{ .Values.intel.secret | b64enc | quote }}
+{{- end }}

--- a/charts/collab/values.yaml
+++ b/charts/collab/values.yaml
@@ -37,6 +37,11 @@ imageCredentials:
 openshift:
   enabled: false
 
+# Optional: use an existing secret for Intel connection
+intelsecret:
+  enabled: false              # default OFF - chart-managed secret
+  ref: ""                     # name of existing Secret (must have keys: url, secret)
+
 #
 # Values required for establishing connection with the Intel server.
 #


### PR DESCRIPTION
Fixes: #170

- add values: intelsecret.enabled/ref
- conditionally render templates/secret-intel.yaml
- deployment envs read from external secret when enabled(fail if ref missing)
- default unchanged (chart still creates "release"-intel)