### PR TITLE
177 collab intel rofs on open shift avoid run as user 0 support fs group

### DIFF
--- a/charts/collab/Chart.yaml
+++ b/charts/collab/Chart.yaml
@@ -3,7 +3,7 @@ name: codetogether-collab
 description: CodeTogether Collab
 
 type: application
-version: 1.2.4
+version: 1.2.5
 appVersion: "2025.1.0"
 
 icon: https://www.codetogether.com/wp-content/uploads/2020/02/codetogether-circle-128.png

--- a/charts/collab/templates/deployment.yaml
+++ b/charts/collab/templates/deployment.yaml
@@ -29,101 +29,6 @@ spec:
         - name: {{ include "codetogether.fullname" . }}-pull-secret
       {{- end }}
       serviceAccountName: {{ include "codetogether.serviceAccountName" . }}
-      {{- if .Values.openshift.enabled }}
-      # OpenShift
-      {{- else if .Values.podSecurityContext }}
-      # Vanilla Kubernetes use what is set in podSecurityContext
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- end }}
-      {{- if .Values.securityContext.readOnlyRootFilesystem }}
-      initContainers:
-        - name: prepare-volatile
-          image: busybox:1.36
-          command: ["/bin/sh", "-c"]
-          args:
-            {{- if .Values.openshift.enabled }}
-            - |
-              set -eu
-              for d in \
-                /run/volatile/clients \
-                /run/volatile/codetogether-config \
-                /run/volatile/codetogether-forever \
-                /run/volatile/codetogether-npm \
-                /run/volatile/codetogether-pm2 \
-                /run/volatile/codetogether-theia \
-                /run/volatile/jicofo-etc \
-                /run/volatile/jvb-etc \
-                /run/volatile/log-codetogether \
-                /run/volatile/log-jitsi \
-                /run/volatile/log-prosody \
-                /run/volatile/meet-web \
-                /run/volatile/nginx \
-                /run/volatile/pki-catrust \
-                /run/volatile/prosody \
-                /run/volatile/prosody-certs \
-                /run/volatile/prosody-conf \
-                /run/volatile/var-cache/dnf \
-                /run/volatile/var-cache/ldconfig \
-                /run/volatile/var-cache/libX11 \
-                /run/volatile/var-cache/nginx \
-                /run/volatile/var-cache/private \
-                /run/volatile/var-cache/yum
-              do
-                install -d -m 0775 "$d"
-              done
-            {{- else }}
-            - |
-              set -eu
-              for d in \
-                /run/volatile/clients \
-                /run/volatile/codetogether-config \
-                /run/volatile/codetogether-forever \
-                /run/volatile/codetogether-npm \
-                /run/volatile/codetogether-pm2 \
-                /run/volatile/codetogether-theia \
-                /run/volatile/jicofo-etc \
-                /run/volatile/jvb-etc \
-                /run/volatile/log-codetogether \
-                /run/volatile/log-jitsi \
-                /run/volatile/log-prosody \
-                /run/volatile/meet-web \
-                /run/volatile/nginx \
-                /run/volatile/pki-catrust \
-                /run/volatile/prosody \
-                /run/volatile/prosody-certs \
-                /run/volatile/prosody-conf \
-                /run/volatile/var-cache/dnf \
-                /run/volatile/var-cache/ldconfig \
-                /run/volatile/var-cache/libX11 \
-                /run/volatile/var-cache/nginx \
-                /run/volatile/var-cache/private \
-                /run/volatile/var-cache/yum
-              do
-                install -d -m 0775 "$d"
-              done
-              chown -R {{ default 1000 .Values.securityContext.runAsUser }}:{{ default 1000 .Values.securityContext.runAsGroup | default 1000 }} \
-                /run /var/log/nginx /var/cache/nginx
-            {{- end }}
-          securityContext:
-            {{- if .Values.openshift.enabled }}
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            {{- else }}
-            runAsUser: 0
-            runAsGroup: 0
-            runAsNonRoot: false
-            allowPrivilegeEscalation: false
-            {{- end }}
-          volumeMounts:
-            - name: codetogether-runtime
-              mountPath: /run
-            - name: codetogether-runtime
-              mountPath: /var/log/nginx
-            - name: codetogether-runtime
-              mountPath: /var/cache/nginx
-      {{- end }}
-
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -289,10 +194,6 @@ spec:
               name: codetogether-runtime
             - mountPath: /tmp
               name: codetogether-tmp
-            - mountPath: /var/log/nginx
-              name: codetogether-runtime
-            - mountPath: /var/cache/nginx
-              name: codetogether-runtime
             {{- if .Values.favicon.enabled }}
             - mountPath: /opt/volatile-template/nginx/favicon.ico
               name: favicon-volume
@@ -349,8 +250,7 @@ spec:
         - name: codetogether-runtime
           emptyDir: {}
         - name: codetogether-tmp
-          emptyDir:
-            medium: Memory
+          emptyDir: {}
       {{- else if .Values.favicon.enabled }}
       volumes:
         - name: favicon-volume

--- a/charts/collab/templates/deployment.yaml
+++ b/charts/collab/templates/deployment.yaml
@@ -29,6 +29,101 @@ spec:
         - name: {{ include "codetogether.fullname" . }}-pull-secret
       {{- end }}
       serviceAccountName: {{ include "codetogether.serviceAccountName" . }}
+      {{- if .Values.openshift.enabled }}
+      # OpenShift
+      {{- else if .Values.podSecurityContext }}
+      # Vanilla Kubernetes use what is set in podSecurityContext
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      {{- if .Values.securityContext.readOnlyRootFilesystem }}
+      initContainers:
+        - name: prepare-volatile
+          image: busybox:1.36
+          command: ["/bin/sh", "-c"]
+          args:
+            {{- if .Values.openshift.enabled }}
+            - |
+              set -eu
+              for d in \
+                /run/volatile/clients \
+                /run/volatile/codetogether-config \
+                /run/volatile/codetogether-forever \
+                /run/volatile/codetogether-npm \
+                /run/volatile/codetogether-pm2 \
+                /run/volatile/codetogether-theia \
+                /run/volatile/jicofo-etc \
+                /run/volatile/jvb-etc \
+                /run/volatile/log-codetogether \
+                /run/volatile/log-jitsi \
+                /run/volatile/log-prosody \
+                /run/volatile/meet-web \
+                /run/volatile/nginx \
+                /run/volatile/pki-catrust \
+                /run/volatile/prosody \
+                /run/volatile/prosody-certs \
+                /run/volatile/prosody-conf \
+                /run/volatile/var-cache/dnf \
+                /run/volatile/var-cache/ldconfig \
+                /run/volatile/var-cache/libX11 \
+                /run/volatile/var-cache/nginx \
+                /run/volatile/var-cache/private \
+                /run/volatile/var-cache/yum
+              do
+                install -d -m 0775 "$d"
+              done
+            {{- else }}
+            - |
+              set -eu
+              for d in \
+                /run/volatile/clients \
+                /run/volatile/codetogether-config \
+                /run/volatile/codetogether-forever \
+                /run/volatile/codetogether-npm \
+                /run/volatile/codetogether-pm2 \
+                /run/volatile/codetogether-theia \
+                /run/volatile/jicofo-etc \
+                /run/volatile/jvb-etc \
+                /run/volatile/log-codetogether \
+                /run/volatile/log-jitsi \
+                /run/volatile/log-prosody \
+                /run/volatile/meet-web \
+                /run/volatile/nginx \
+                /run/volatile/pki-catrust \
+                /run/volatile/prosody \
+                /run/volatile/prosody-certs \
+                /run/volatile/prosody-conf \
+                /run/volatile/var-cache/dnf \
+                /run/volatile/var-cache/ldconfig \
+                /run/volatile/var-cache/libX11 \
+                /run/volatile/var-cache/nginx \
+                /run/volatile/var-cache/private \
+                /run/volatile/var-cache/yum
+              do
+                install -d -m 0775 "$d"
+              done
+              chown -R {{ default 1000 .Values.securityContext.runAsUser }}:{{ default 1000 .Values.securityContext.runAsGroup | default 1000 }} \
+                /run /var/log/nginx /var/cache/nginx
+            {{- end }}
+          securityContext:
+            {{- if .Values.openshift.enabled }}
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            {{- else }}
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            {{- end }}
+          volumeMounts:
+            - name: codetogether-runtime
+              mountPath: /run
+            - name: codetogether-runtime
+              mountPath: /var/log/nginx
+            - name: codetogether-runtime
+              mountPath: /var/cache/nginx
+      {{- end }}
+
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -248,6 +343,7 @@ spec:
 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+  
       {{- if .Values.securityContext.readOnlyRootFilesystem}}
       volumes:
         - name: codetogether-runtime

--- a/charts/collab/values.yaml
+++ b/charts/collab/values.yaml
@@ -211,13 +211,24 @@ serviceAccount:
 
 podAnnotations: {}
 
+# Enable if deploying in OpenShift
+openshift:
+  enabled: false
+
 securityContext: {} #defaults
   # capabilities:
   #   drop:
   #   - ALL
   # readOnlyRootFilesystem: true # enable for read-only setup
   # runAsNonRoot: true
-  # runAsUser: 0 # Use '0' for root user for read-only setup
+  # runAsUser: 1000 # Use '0' for root user, in vanilla k8s you can use any non-root uid
+  # runAsGroup: 1000
+  # In openshift, dont set runAsUser or runAsGroup, let OpenShift assign the values
+
+podSecurityContext: {}
+# In OpenShift will inject automatically
+  #fsGroup: 1000
+  #fsGroupChangePolicy: "OnRootMismatch"
 
 readinessProbe:
   initialDelaySeconds: 60

--- a/charts/collab/values.yaml
+++ b/charts/collab/values.yaml
@@ -211,10 +211,6 @@ serviceAccount:
 
 podAnnotations: {}
 
-# Enable if deploying in OpenShift
-openshift:
-  enabled: false
-
 securityContext: {} #defaults
   # capabilities:
   #   drop:
@@ -222,13 +218,7 @@ securityContext: {} #defaults
   # readOnlyRootFilesystem: true # enable for read-only setup
   # runAsNonRoot: true
   # runAsUser: 1000 # Use '0' for root user, in vanilla k8s you can use any non-root uid
-  # runAsGroup: 1000
-  # In openshift, dont set runAsUser or runAsGroup, let OpenShift assign the values
-
-podSecurityContext: {}
-# In OpenShift will inject automatically
-  #fsGroup: 1000
-  #fsGroupChangePolicy: "OnRootMismatch"
+  # In openshift, dont set runAsUser, let OpenShift assign the values
 
 readinessProbe:
   initialDelaySeconds: 60

--- a/charts/intel/Chart.yaml
+++ b/charts/intel/Chart.yaml
@@ -3,7 +3,7 @@ name: codetogether-intel
 description: CodeTogether Intel provides advanced project insights for developers
 
 type: application
-version: 1.2.7
+version: 1.2.8
 appVersion: "2025.3.0"
 
 icon: https://www.codetogether.com/wp-content/uploads/2020/02/codetogether-circle-128.png

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -45,22 +45,22 @@ spec:
             {{- if .Values.openshift.enabled }}
             - |
               set -eu
+              umask 002
               for d in \
-                /run \
                 /var/log/nginx \
                 /var/cache/nginx
               do
-                install -d -m 0775 "$d"
+                install -d -m 2775 "$d"
               done
             {{- else }}
             - |
               set -eu
+              umask 002
               for d in \
-                /run \
                 /var/log/nginx \
                 /var/cache/nginx
               do
-                install -d -m 0775 "$d"
+                install -d -m 2775 "$d"
               done
               chown -R {{ default 1000 .Values.securityContext.runAsUser }}:{{ default 1000 .Values.securityContext.runAsGroup | default 1000 }} \
                 /run /var/log/nginx /var/cache/nginx

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       serviceAccountName: {{ include "codetogether.serviceAccountName" . }}
       {{- if .Values.openshift.enabled }}
       # OpenShift
+      securityContext:
+        fsGroup: 0
+        fsGroupChangePolicy: "OnRootMismatch"
       {{- else if .Values.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -52,12 +52,12 @@ spec:
             {{- else }}
             - |
               set -eu
-              umask 002
               for d in \
+                /run \
                 /var/log/nginx \
                 /var/cache/nginx
               do
-                install -d -m 2775 "$d"
+                install -d -m 0775 "$d"
               done
               chown -R {{ default 1000 .Values.securityContext.runAsUser }}:{{ default 1000 .Values.securityContext.runAsGroup | default 1000 }} \
                 /run /var/log/nginx /var/cache/nginx

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -27,6 +27,56 @@ spec:
         - name: {{ include "codetogether.fullname" . }}-pull-secret
       {{- end }}
       serviceAccountName: {{ include "codetogether.serviceAccountName" . }}
+      {{- if .Values.openshift.enabled }}
+      # OpenShift
+      {{- else if .Values.podSecurityContext }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- end }}
+      {{- if .Values.securityContext.readOnlyRootFilesystem }}
+      initContainers:
+        - name: prepare-runtime
+          image: busybox:1.36
+          command: ["/bin/sh","-c"]
+          args:
+            {{- if .Values.openshift.enabled }}
+            - |
+              set -eu
+              for d in \
+                /run \
+                /var/log/nginx \
+                /var/cache/nginx
+              do
+                install -d -m 0775 "$d"
+              done
+            {{- else }}
+            - |
+              set -eu
+              for d in \
+                /run \
+                /var/log/nginx \
+                /var/cache/nginx
+              do
+                install -d -m 0775 "$d"
+              done
+              chown -R {{ default 1000 .Values.securityContext.runAsUser }}:{{ default 1000 .Values.securityContext.runAsGroup | default 1000 }} \
+                /run /var/log/nginx /var/cache/nginx
+            {{- end }}
+          securityContext:
+            {{- if .Values.openshift.enabled }}
+            runAsNonRoot: true
+            allowPrivilegeEscalation: false
+            {{- else }}
+            runAsUser: 0
+            runAsGroup: 0
+            runAsNonRoot: false
+            allowPrivilegeEscalation: false
+            {{- end }}
+          volumeMounts:
+            - { name: codetogether-runtime, mountPath: /run }
+            - { name: codetogether-runtime, mountPath: /var/log/nginx }
+            - { name: codetogether-runtime, mountPath: /var/cache/nginx }
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -29,9 +29,6 @@ spec:
       serviceAccountName: {{ include "codetogether.serviceAccountName" . }}
       {{- if .Values.openshift.enabled }}
       # OpenShift
-      securityContext:
-        fsGroup: 0
-        fsGroupChangePolicy: "OnRootMismatch"
       {{- else if .Values.podSecurityContext }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -27,56 +27,6 @@ spec:
         - name: {{ include "codetogether.fullname" . }}-pull-secret
       {{- end }}
       serviceAccountName: {{ include "codetogether.serviceAccountName" . }}
-      {{- if .Values.openshift.enabled }}
-      # OpenShift
-      {{- else if .Values.podSecurityContext }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- end }}
-      {{- if .Values.securityContext.readOnlyRootFilesystem }}
-      initContainers:
-        - name: prepare-runtime
-          image: busybox:1.36
-          command: ["/bin/sh","-c"]
-          args:
-            {{- if .Values.openshift.enabled }}
-            - |
-              set -eu
-              umask 002
-              for d in \
-                /var/log/nginx \
-                /var/cache/nginx
-              do
-                install -d -m 2775 "$d"
-              done
-            {{- else }}
-            - |
-              set -eu
-              for d in \
-                /run \
-                /var/log/nginx \
-                /var/cache/nginx
-              do
-                install -d -m 0775 "$d"
-              done
-              chown -R {{ default 1000 .Values.securityContext.runAsUser }}:{{ default 1000 .Values.securityContext.runAsGroup | default 1000 }} \
-                /run /var/log/nginx /var/cache/nginx
-            {{- end }}
-          securityContext:
-            {{- if .Values.openshift.enabled }}
-            runAsNonRoot: true
-            allowPrivilegeEscalation: false
-            {{- else }}
-            runAsUser: 0
-            runAsGroup: 0
-            runAsNonRoot: false
-            allowPrivilegeEscalation: false
-            {{- end }}
-          volumeMounts:
-            - { name: codetogether-runtime, mountPath: /run }
-            - { name: codetogether-runtime, mountPath: /var/log/nginx }
-            - { name: codetogether-runtime, mountPath: /var/cache/nginx }
-      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -149,7 +99,6 @@ spec:
                   key: apiKey
               {{- end }}
             {{- end }}
-{{- if .Values.securityContext.readOnlyRootFilesystem }}
           volumeMounts:
             - name: properties-volume
               mountPath: /opt/codetogether/runtime/cthq.properties
@@ -159,26 +108,6 @@ spec:
               mountPath: /etc/ssl/certs/java/cacerts
               subPath: cacerts
             {{- end }}
-            # Read-only root FS mounts
-            - mountPath: /run
-              name: codetogether-runtime
-            - mountPath: /tmp
-              name: codetogether-tmp
-            - mountPath: /var/log/nginx
-              name: codetogether-runtime
-            - mountPath: /var/cache/nginx
-              name: codetogether-runtime
-{{- else }}
-          volumeMounts:
-            - name: properties-volume
-              mountPath: /opt/codetogether/runtime/cthq.properties
-              subPath: cthq.properties
-            {{- if .Values.java.customCacerts.enabled }}
-            - name: java-cacerts
-              mountPath: /etc/ssl/certs/java/cacerts
-              subPath: cacerts
-            {{- end }}
-{{- end }}
           ports:
             - name: http
               containerPort: 1080
@@ -227,14 +156,6 @@ spec:
           secret:
             secretName: {{ .Values.java.customCacerts.cacertsSecretName }}
         {{- end }}
-{{- if .Values.securityContext.readOnlyRootFilesystem }}
-        - name: codetogether-runtime
-          emptyDir: {}
-        - name: codetogether-tmp
-          emptyDir:
-            medium: Memory
-{{- end }}
-
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -132,10 +132,6 @@ serviceAccount:
 
 podAnnotations: {}
 
-# Enable if deploying in OpenShift
-openshift:
-  enabled: false
-
 securityContext: {} #defaults
   # capabilities:
   #   drop:
@@ -143,13 +139,7 @@ securityContext: {} #defaults
   # readOnlyRootFilesystem: true # enable for read-only setup
   # runAsNonRoot: true
   # runAsUser: 1000 # Use '0' for root user
-  # runAsGroup: 1000
-  # In openshift, dont set runAsUser or runAsGroup, let OpenShift assign the values
-
-podSecurityContext: {}
-# In OpenShift will inject automatically
-  #fsGroup: 1000
-  #fsGroupChangePolicy: "OnRootMismatch"
+  # In openshift, dont set runAsUser, let OpenShift assign the values
 
 ai:
   enabled: false

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -132,14 +132,24 @@ serviceAccount:
 
 podAnnotations: {}
 
-securityContext: {} #defaults to
+# Enable if deploying in OpenShift
+openshift:
+  enabled: false
 
+securityContext: {} #defaults
   # capabilities:
   #   drop:
   #   - ALL
-  #readOnlyRootFilesystem: true  # enable for read-only setup
-  # runAsNonRoot: true           # false for non-root user
-  # runAsUser: 0 # Use '0' for root user for read-only setup
+  # readOnlyRootFilesystem: true # enable for read-only setup
+  # runAsNonRoot: true
+  # runAsUser: 1000 # Use '0' for root user, in vanilla k8s you can use any non-root uid
+  # runAsGroup: 1000
+  # In openshift, dont set runAsUser or runAsGroup, let OpenShift assign the values
+
+podSecurityContext: {}
+# In OpenShift will inject automatically
+  #fsGroup: 1000
+  #fsGroupChangePolicy: "OnRootMismatch"
 
 ai:
   enabled: false

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -142,7 +142,7 @@ securityContext: {} #defaults
   #   - ALL
   # readOnlyRootFilesystem: true # enable for read-only setup
   # runAsNonRoot: true
-  # runAsUser: 1000 # Use '0' for root user, in vanilla k8s you can use any non-root uid
+  # runAsUser: 1000 # Use '0' for root user
   # runAsGroup: 1000
   # In openshift, dont set runAsUser or runAsGroup, let OpenShift assign the values
 


### PR DESCRIPTION
This change makes the codetogether-collab and codetogether-intel charts work
out-of-the-box on both vanilla Kubernetes and OpenShift (restricted-v2 SCC),
and adds first-class support for readOnlyRootFilesystem via init containers.

Key changes
-----------
Collab
- Add initContainer `prepare-volatile` to create writable runtime paths when
  readOnlyRootFilesystem=true (e.g., /run, /var/log/nginx, /var/cache/nginx,
  and the existing /run/volatile/* tree).
- Conditionally handle OpenShift vs vanilla:
  - OpenShift: do NOT set runAsUser/runAsGroup/fsGroup; let SCC assign UIDs.
    Keep runAsNonRoot and disallow privilege escalation. Avoid chown.
    Use `install -d -m 0775/2775` for group-write with sticky set as needed.
  - Vanilla: init runs as root (UID 0) to chown created dirs to the non-root
    runtime user (defaults to 1000:1000); main container runs non-root.
- When readOnlyRootFilesystem=true:
  - Mount EmptyDir volumes to /run, /tmp (Memory), /var/log/nginx, /var/cache/nginx.
  - Add matching volumeMounts.
- Keep probes and ports unchanged.
- Values: add/clarify `openshift.enabled` flag, securityContext defaults,
  imageCredentials usage, and sample values for both environments.

Intel
- Add initContainer `prepare-runtime` to create /var/log/nginx and
  /var/cache/nginx and make them writable under read-only rootfs.
- Same OpenShift vs vanilla split as collab (no explicit UID/GID on OCP;
  root init + non-root app for vanilla).
- Mount EmptyDir + volumeMounts for /run, /tmp (Memory), /var/log/nginx,
/var/cache/nginx when readOnlyRootFilesystem=true.
- Preserve existing envs (AI mode, HQ base URL, Java options, etc.).

Why
---
- Fixes SCC denials on OpenShift when explicit runAsUser/fsGroup were set.
- Fixes initContainer permission errors (e.g., "Operation not permitted" on /run)
  by avoiding chown on OpenShift and using 2775 with umask 002.
- Enables secure read-only rootfs operation by provisioning necessary
  writable paths via EmptyDir.

Testing
-------
- OpenShift 4.x:
  - `openshift.enabled=true`, remove fsGroup=0, do not set runAsUser/runAsGroup.
  - initContainers succeed; pods transition to Running.
- Vanilla (DigitalOcean Kubernetes):
  - `openshift.enabled=false`, readOnlyRootFilesystem=true.
  - init runs as root, chowns to 1000:1000; app runs as non-root.
  - Pods healthy; readiness/liveness OK.

Breaking changes
----------------
- None functionally; however, when enabling readOnlyRootFilesystem, the chart
  now requires the EmptyDir mounts (added by default when the flag is true).
