### PR TITLE
intel(chart): enable read-only FS support

### DIFF
--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -119,8 +119,6 @@ spec:
           {{- if .Values.securityContext.readOnlyRootFilesystem }}
             - name: run-volatile
               mountPath: /run/volatile
-            - name: var-log-nginx
-              mountPath: /var/log/nginx
             - name: run-nginx
               mountPath: /run
             - name: tmp
@@ -178,10 +176,6 @@ spec:
         {{- end }}
         {{- if .Values.securityContext.readOnlyRootFilesystem }}
         - name: run-volatile
-          emptyDir: {}
-        - name: var-log-nginx
-          emptyDir: {}
-        - name: run-nginx
           emptyDir: {}
         - name: tmp
           emptyDir:


### PR DESCRIPTION
Fixes #190

- Add initContainer to mkdir/chown /run/volatile/*, /var/log/nginx, /var/cache/nginx
- Mount EmptyDir at /run, /var/log/nginx, /var/cache/nginx, /tmp, /var/tmp
- Fix writes under /run/volatile and nginx pid/log on RO FS