### PR TITLE
feat(helm): add warning log when deprecated AV settings are detected

### DIFF
--- a/charts/collab/templates/deployment.yaml
+++ b/charts/collab/templates/deployment.yaml
@@ -110,6 +110,15 @@ spec:
           {{- if or (eq .Values.codetogether.mode "direct") (eq .Values.codetogether.mode "locator-edge") }}
           - name: CT_AV_ENABLED
             value: {{ .Values.av.enabled | quote }}
+
+          # ------------------------------
+          # A/V DEPRECATION NOTICE
+          # ------------------------------
+          {{- if or .Values.av.enabled .Values.av.serverIP .Values.av.stunServers.enabled .Values.av.jitsiUrl }}
+          - name: CT_AV_DEPRECATED_WARNING
+            value: "Audio/Video options detected in Helm values, but A/V is no longer supported and will be ignored."
+          {{- end }}
+
           {{- if .Values.av.enabled }} 
           - name: CT_AV_LAN_IP
             value: {{ .Values.av.serverIP | quote }}


### PR DESCRIPTION
Fixes: #192

- Added a startup warning when any Audio/Video related values (av.enabled, av.serverIP, av.stunServers, av.jitsiUrl) are present in Helm chart configurations.
- Ensures deployments are notified that built in A/V support is no longer available.
- No functional behavior changed, only logs a warning at container start.