### PR TITLE
feat(helm): add optional service annotations to collab chart Service

### DIFF
--- a/charts/collab/templates/service.yaml
+++ b/charts/collab/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "codetogether.fullname" . }}
   labels:
     {{- include "codetogether.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/collab/values.yaml
+++ b/charts/collab/values.yaml
@@ -203,6 +203,7 @@ av:
 service:
   type: ClusterIP
   port: 443
+  annotations: {}
 
 serviceAccount:
   create: true


### PR DESCRIPTION
Fixes: #198

- add service.annotations to values.yaml with default {}
- render metadata.annotations in templates/service.yaml via .Values.service.annotations
- keep backward compatibility when annotations are not set