### PR TITLE
CTPD-4358 Make health probe path port configurable in codetogether-intel helm chart

### DIFF
--- a/charts/intel/Chart.yaml
+++ b/charts/intel/Chart.yaml
@@ -3,7 +3,7 @@ name: codetogether-intel
 description: CodeTogether Intel provides advanced project insights for developers
 
 type: application
-version: 1.3.4
+version: 1.3.5
 appVersion: "2026.1.2"
 
 icon: https://www.codetogether.com/wp-content/uploads/2020/02/codetogether-circle-128.png

--- a/charts/intel/templates/deployment.yaml
+++ b/charts/intel/templates/deployment.yaml
@@ -147,8 +147,8 @@ spec:
             successThreshold: {{ .Values.livenessProbe.successThreshold }}
             failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
             httpGet:
-              path: /
-              port: http
+              path: {{ .Values.livenessProbe.path | default "/" }}
+              port: {{ .Values.livenessProbe.port | default "http" }}
 
           readinessProbe:
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
@@ -157,8 +157,8 @@ spec:
             successThreshold: {{ .Values.readinessProbe.successThreshold }}
             failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
             httpGet:
-              path: /
-              port: http
+              path: {{ .Values.readinessProbe.path | default "/" }}
+              port: {{ .Values.readinessProbe.port | default "http" }}
 
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/intel/values.yaml
+++ b/charts/intel/values.yaml
@@ -173,6 +173,8 @@ ai:
       #memory: "4Gi"
 
 readinessProbe:
+  path: /
+  port: http
   initialDelaySeconds: 60
   periodSeconds: 60
   timeoutSeconds: 15
@@ -180,6 +182,8 @@ readinessProbe:
   failureThreshold: 1
 
 livenessProbe:
+  path: /
+  port: http
   initialDelaySeconds: 60
   periodSeconds: 60
   timeoutSeconds: 15


### PR DESCRIPTION
## Summary
- Templates the hardcoded `path: /` and `port: http` in liveness and readiness probes in `deployment.yaml` so they can be overridden via `values.yaml`.
- Adds `path` and `port` fields to both probe blocks in `values.yaml` with backward-compatible defaults (`/` and `http`).
- Bumps chart version from `1.3.4` to `1.3.5`.

## Why
The SaaS staging deployment needs probes at `/actuator/health` and `/actuator/health/readiness` on port `8080`, but the chart ignored these values because the paths and ports were hardcoded.

## Safety
- Existing customers on 1.3.4 are completely untouched.
- Customers upgrading to 1.3.5 without setting `path`/`port` get identical behavior due to defaults.
- Only deployments that explicitly override `path` and `port` get different probe behavior.

CTPD-4358