### PR TITLE
[codex] AITRAX-581 support immutable standalone Live images

### DIFF
--- a/charts/live/Chart.yaml
+++ b/charts/live/Chart.yaml
@@ -3,7 +3,7 @@ name: codetogether
 description: CodeTogether Live provides pair programming and collaborative coding
 
 type: application
-version: 1.4.25
+version: 1.4.26
 appVersion: "2024.2.0"
 
 icon: https://www.codetogether.com/wp-content/uploads/2020/02/codetogether-circle-128.png

--- a/charts/live/README.md
+++ b/charts/live/README.md
@@ -1,8 +1,8 @@
 # README.md Helm Chart for CodeTogether Live
 # CodeTogether Live Chart (Legacy)
 
-> **⚠️ Legacy Chart**  
-> This chart is now considered legacy and is not longer supported, is not recommended for new deployments.
+> **⚠️ Legacy Chart**
+> This chart is considered legacy, is no longer supported, and is not recommended for new deployments.
 
 ## Summary
 This chart creates a CodeTogether Live server deployment on a Kubernetes cluster using the Helm package manager.

--- a/charts/live/README.md
+++ b/charts/live/README.md
@@ -25,6 +25,7 @@ The following table lists configurable parameters of the CodeTogether Live chart
 | `image.repository`                          | Docker image repository for CodeTogether Live                                                  | `codetogether/codetogether`                               |
 | `image.pullPolicy`                          | Container image pull policy                                                                    | `Always`                                                  |
 | `image.tag`                                 | Tag for the CodeTogether Live image                                                            | `latest`                                                  |
+| `image.digest`                              | Optional immutable image digest; takes precedence over `image.tag`                             | `""`                                                      |
 | `imageCredentials.enabled`                  | Enables authentication for private Docker registry                                             | `false`                                                   |
 | `imageCredentials.registry`                 | Docker registry URL                                                                            | `hub.edge.codetogether.com`                               |
 | `imageCredentials.username`                 | Docker registry username                                                                       | `my-customer-username`                                    |

--- a/charts/live/templates/_helpers.tpl
+++ b/charts/live/templates/_helpers.tpl
@@ -24,6 +24,15 @@ If release name contains chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Return true when A/V is enabled for a supported Live deployment mode.
+*/}}
+{{- define "codetogether.avEnabled" -}}
+{{- if and .Values.av.enabled (or (eq .Values.codetogether.mode "direct") (eq .Values.codetogether.mode "locator-edge")) -}}
+true
+{{- end -}}
+{{- end }}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "codetogether.chart" -}}

--- a/charts/live/templates/deployment.yaml
+++ b/charts/live/templates/deployment.yaml
@@ -11,7 +11,9 @@ spec:
   template:
     metadata:
       annotations:
+        {{- if and .Values.av.enabled .Values.av.stunServers.enabled }}
         checksum/coturn: {{ include (print $.Template.BasePath "/secret-coturn.yaml") . | sha256sum }}
+        {{- end }}
         checksum/dashboard: {{ include (print $.Template.BasePath "/secret-dashboard.yaml") . | sha256sum }}
         checksum/license: {{ include (print $.Template.BasePath "/secret-license.yaml") . | sha256sum }}
         checksum/sso: {{ include (print $.Template.BasePath "/secret-sso.yaml") . | sha256sum }}
@@ -34,7 +36,11 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
+          {{- if .Values.image.digest }}
+          image: "{{ .Values.image.repository }}@{{ .Values.image.digest }}"
+          {{- else }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          {{- end }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
 
           env:
@@ -113,7 +119,7 @@ spec:
             value: "false"
           {{- end }}
 
-          {{- if .Values.av.stunServers.enabled }}
+          {{- if and .Values.av.enabled .Values.av.stunServers.enabled }}
           - name: CT_AV_COTURN_SERVER
             value: {{ .Values.av.stunServers.server | quote }}
           - name: CT_AV_COTURN_SECRET
@@ -123,7 +129,7 @@ spec:
                 key: secret
           {{- end }}
 
-          {{- if and .Values.av.jitsiUrl (ne .Values.av.jitsiUrl "") }}
+          {{- if and .Values.av.enabled .Values.av.jitsiUrl (ne .Values.av.jitsiUrl "") }}
           - name: CT_JITSI_URL
             value: {{ .Values.av.jitsiUrl | quote }}
           {{- end }}

--- a/charts/live/templates/deployment.yaml
+++ b/charts/live/templates/deployment.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if and .Values.av.enabled .Values.av.stunServers.enabled }}
+        {{- if and (include "codetogether.avEnabled" .) .Values.av.stunServers.enabled }}
         checksum/coturn: {{ include (print $.Template.BasePath "/secret-coturn.yaml") . | sha256sum }}
         {{- end }}
         checksum/dashboard: {{ include (print $.Template.BasePath "/secret-dashboard.yaml") . | sha256sum }}
@@ -107,19 +107,14 @@ spec:
             value: {{ .Values.locatorEdge.region | quote }}
           {{- end }}  
 
-          {{- if or (eq .Values.codetogether.mode "direct") (eq .Values.codetogether.mode "locator-edge") }}
           - name: CT_AV_ENABLED
-            value: {{ .Values.av.enabled | quote }}
-          {{- if .Values.av.enabled }} 
+            value: {{ include "codetogether.avEnabled" . | default "false" | quote }}
+          {{- if include "codetogether.avEnabled" . }}
           - name: CT_AV_LAN_IP
             value: {{ .Values.av.serverIP | quote }}
           {{- end }}
-          {{- else }}
-          - name: CT_AV_ENABLED
-            value: "false"
-          {{- end }}
 
-          {{- if and .Values.av.enabled .Values.av.stunServers.enabled }}
+          {{- if and (include "codetogether.avEnabled" .) .Values.av.stunServers.enabled }}
           - name: CT_AV_COTURN_SERVER
             value: {{ .Values.av.stunServers.server | quote }}
           - name: CT_AV_COTURN_SECRET
@@ -129,7 +124,7 @@ spec:
                 key: secret
           {{- end }}
 
-          {{- if and .Values.av.enabled .Values.av.jitsiUrl (ne .Values.av.jitsiUrl "") }}
+          {{- if and (include "codetogether.avEnabled" .) .Values.av.jitsiUrl (ne .Values.av.jitsiUrl "") }}
           - name: CT_JITSI_URL
             value: {{ .Values.av.jitsiUrl | quote }}
           {{- end }}
@@ -240,7 +235,7 @@ spec:
             - name: http
               containerPort: 1080
               protocol: TCP
-            {{- if .Values.av.enabled }}
+            {{- if include "codetogether.avEnabled" . }}
             - name: av-tcp
               containerPort: 4443
               protocol: TCP

--- a/charts/live/templates/deployment.yaml
+++ b/charts/live/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           env:
           #
           # Set CodeTogether runtime configuration
-          #         
+          #
           - name: CT_SERVER_URL
             value: {{ .Values.codetogether.url | quote }}
           - name: CT_TRUST_ALL_CERTS
@@ -56,7 +56,7 @@ spec:
           - name: CT_LOCATOR
             value: "none"
           - name: CT_PROMETHEUS_ENABLED
-            value: {{ .Values.direct.metrics.prometheusEnabled | quote }}         
+            value: {{ .Values.direct.metrics.prometheusEnabled | quote }}
           {{- if .Values.direct.metrics.statsdEnabled }}
           - name: CT_METRICS_STATSD_HOST
             value: {{ .Values.direct.metrics.statsdHost | quote }}
@@ -105,7 +105,7 @@ spec:
             value: {{ .Values.locatorEdge.locator | quote }}
           - name: CT_REGION
             value: {{ .Values.locatorEdge.region | quote }}
-          {{- end }}  
+          {{- end }}
 
           - name: CT_AV_ENABLED
             value: {{ include "codetogether.avEnabled" . | default "false" | quote }}
@@ -228,7 +228,7 @@ spec:
               subPath: favicon.ico
           {{- end }}
 
-          # 
+          #
           # Set container configuration
           #
           ports:
@@ -243,7 +243,7 @@ spec:
               containerPort: 10000
               protocol: UDP
             {{- end }}
-          
+
           livenessProbe:
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
@@ -253,7 +253,7 @@ spec:
             httpGet:
               path: /ct-health/
               port: http
-          
+
           readinessProbe:
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds }}

--- a/charts/live/templates/secret-coturn.yaml
+++ b/charts/live/templates/secret-coturn.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.av.enabled .Values.av.stunServers.enabled }}
+{{- if and (include "codetogether.avEnabled" .) .Values.av.stunServers.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/live/templates/secret-coturn.yaml
+++ b/charts/live/templates/secret-coturn.yaml
@@ -1,3 +1,4 @@
+{{- if and .Values.av.enabled .Values.av.stunServers.enabled }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
 type: Opaque
 data:
   secret: {{ .Values.av.stunServers.secret | b64enc | quote }}
+{{- end }}

--- a/charts/live/templates/service.yaml
+++ b/charts/live/templates/service.yaml
@@ -11,7 +11,7 @@ spec:
       targetPort: http
       protocol: TCP
       name: http  
-    {{- if .Values.av.enabled }}
+    {{- if include "codetogether.avEnabled" . }}
     - port: 4443
       targetPort: av-tcp
       protocol: TCP

--- a/charts/live/templates/service.yaml
+++ b/charts/live/templates/service.yaml
@@ -10,7 +10,7 @@ spec:
     - port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
-      name: http  
+      name: http
     {{- if include "codetogether.avEnabled" . }}
     - port: 4443
       targetPort: av-tcp

--- a/charts/live/values.yaml
+++ b/charts/live/values.yaml
@@ -77,7 +77,7 @@ codetogether:
 #
 # Configure if CodeTogether is running in 'direct' mode.
 #
-direct: 
+direct:
   # When running in 'direct' mode, integration with StatsD or Prometheus can be
   # enabled in the Docker file. For Locator deployments, configure dynamically
   # on the locator's Dashboard.
@@ -100,7 +100,7 @@ locatorCentral:
     port: 3306
     schema: "codetogether"
     # Supported values: 'mysql' or 'postgres'
-    dialect: "mysql"  
+    dialect: "mysql"
     user: "my-db-username"
     password: "my-db-password"
     # Optionally enable SSL security to database
@@ -113,14 +113,14 @@ locatorCentral:
     # sslKey: "my-db-ssl-key-base64-encoded"
     # sslCA: "my-db-ssl-certificate-authority-base64-encoded"
     # sslCert: "my-db-ssl-certificate-base64-encoded"
-    
+
 #
 # Configure if CodeTogether is running in 'locator-edge' mode.
 #
 locatorEdge:
   # URL that the Locator is listening on.
   locator: "https://codetogether.locator"
-  # Optional region which can have CIDR IP address regions assigned to 
+  # Optional region which can have CIDR IP address regions assigned to
   # allowing regional routing of requests. Only enable if deploying
   # CodeTogether to multiple regional data centers.
   region: "default"
@@ -160,7 +160,7 @@ ingress:
 #
 # CodeTogether has a dashboard to view metrics, and for the locator, update
 # configuration on the fly. If a custom username and password is not enabled,
-# one will be dynamically generated and shared in the log when the server 
+# one will be dynamically generated and shared in the log when the server
 # starts up. Accessed at https://url/dashboard.
 #
 dashboard:
@@ -168,7 +168,7 @@ dashboard:
   enabled: false
   username: "my-dashboard-username"
   password: "my-dashboard-password"
-  # Name of existing secret to use for Dashboard credentials. If specfied,
+  # Name of existing secret to use for Dashboard credentials. If specified,
   # then dashboard.username and dashboard.password will be ignored and picked up from this secret.
   # existingSecret: ""
 
@@ -178,17 +178,17 @@ dashboard:
 #
 av:
   enabled: false
-  # If auto, will attempt lookup of the IP address of the server. If the 
+  # If auto, will attempt lookup of the IP address of the server. If the
   # container fails to start, IP address can be manually configured.
   serverIP: "auto"
   # Optional - If you want to use your own STUN servers, set this to 'true'
   # and specify <server:port> separated by a comma ','.
-  stunServers: 
+  stunServers:
     enabled: false
     server: "coturn.example.com"
     secret: "my-secret"
-  # Optional - Jitsi Settings for locator edge servers with locator or extenral jitsi meet server
-  # jitsiUrl: "https://your.jtsi.server"
+  # Optional - Jitsi settings for locator edge servers with locator or external Jitsi Meet server
+  # jitsiUrl: "https://your.jitsi.server"
 
 #
 # Optionally enable integration with your SSO Provider. If using SSO, this
@@ -254,7 +254,7 @@ proxy:
   enabled: false
   # Proxy URI format, omit credentials if unauthenticated:
   # http://myuser:mypassword@myproxyhost.com:port
-  # Note: At this point only HTTP proxy is supported. Additionally, 
+  # Note: At this point only HTTP proxy is supported. Additionally,
   # if you are using special characters in the password, please verify escaping.
   uri: ""
   # Name of existing secret to use for proxy URI. If specified,

--- a/charts/live/values.yaml
+++ b/charts/live/values.yaml
@@ -18,6 +18,9 @@ image:
   pullPolicy: Always
   # Overrides the image tag whose default is the chart appVersion.
   tag: "latest"
+  # Optional immutable image digest (sha256:...). When set, digest takes
+  # precedence over tag.
+  digest: ""
 
 #
 # Configure the source location for the Docker image, using the


### PR DESCRIPTION
## What changed

- Add optional digest-based image references to the legacy Live chart while retaining the public `codetogether/codetogether:latest` default.
- Gate the coturn Secret, checksum, environment variables, and Jitsi URL on the top-level `av.enabled` switch.
- Bump the chart version to `1.4.26` and document `image.digest`.

## Why

Standalone promotion is digest-based, but the chart previously accepted only mutable tags. It also rendered the coturn Secret unconditionally and could render nested A/V configuration while A/V was globally disabled.

## Impact

Existing values remain compatible. Standalone deployments can select an immutable promoted digest, and `av.enabled: false` now guarantees that no coturn Secret or Jitsi/coturn configuration is rendered.

## Checks

- Helm 3.15.4 lint
- default render: `CT_AV_ENABLED=false`, no coturn/Jitsi Secret or configuration
- adversarial disabled render with nested coturn/Jitsi values: no coturn/Jitsi Secret or configuration
- enabled render: matching coturn producer/consumer and Jitsi settings
- digest render: repository resolves to `repository@sha256:...` and ignores tag
- `git diff --check`

Related build/artifact-contract PR: CodeTogether-Inc/live#525
